### PR TITLE
Redesign portfolio to Miro design system

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,30 +7,31 @@
   <meta name="description" content="Power BI dashboards, demos, and analytics work by Davenee James." />
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=Bebas+Neue&family=Barlow:wght@300;400;500;600&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@400;500;600;700;800&family=Noto+Sans:wght@400;500;600&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
 
   <style>
     :root {
-      --bg-deep: #0a0a0a;
-      --bg-dark: #111111;
-      --bg-card: #161616;
-      --bg-card-hover: #1a1a1a;
-      --bg-code: #0d1117;
-      --border: rgba(255,255,255,0.08);
-      --border-light: rgba(255,255,255,0.12);
-      --text: #ffffff;
-      --text-muted: rgba(255,255,255,0.6);
-      --text-dim: rgba(255,255,255,0.4);
-      --accent: #3a8fd9;
-      --accent-glow: rgba(58,143,217,0.3);
-      --gold: #c9a227;
+      --near-black: #1c1c1e;
+      --white: #ffffff;
+      --blue: #5b76fe;
+      --blue-pressed: #2a41b6;
+      --slate: #555a6a;
+      --placeholder: #a5a8b5;
+      --border: #c7cad5;
+      --ring: rgb(224,226,232);
+      --success: #00b473;
+      --teal-light: #c3faf5;
+      --teal-dark: #187574;
+      --coral-light: #ffc6c6;
+      --rose-light: #ffd8f4;
+      --orange-light: #ffe6cd;
+      --bg: #ffffff;
+      --bg-subtle: #f8f9fb;
       --code-keyword: #ff7b72;
       --code-function: #d2a8ff;
       --code-string: #a5d6ff;
       --code-comment: #8b949e;
       --code-number: #79c0ff;
-
-      /* Animation timing */
       --ease-apple: cubic-bezier(0.25, 0.46, 0.45, 0.94);
       --ease-spring: cubic-bezier(0.34, 1.56, 0.64, 1);
       --ease-smooth: cubic-bezier(0.16, 1, 0.3, 1);
@@ -40,24 +41,15 @@
     html { scroll-behavior: smooth; }
 
     body {
-      font-family: 'Barlow', sans-serif;
-      background: var(--bg-deep);
-      color: var(--text);
-      line-height: 1.6;
+      font-family: 'Noto Sans', sans-serif;
+      background: var(--bg);
+      color: var(--near-black);
+      line-height: 1.5;
       -webkit-font-smoothing: antialiased;
       overflow-x: hidden;
     }
 
     a { color: inherit; text-decoration: none; }
-
-    body::before {
-      content: '';
-      position: fixed;
-      inset: 0;
-      background: repeating-linear-gradient(0deg, transparent, transparent 2px, rgba(0,0,0,0.03) 2px, rgba(0,0,0,0.03) 4px);
-      pointer-events: none;
-      z-index: 9999;
-    }
 
     .container { max-width: 1200px; margin: 0 auto; padding: 0 40px; }
     @media (max-width: 768px) { .container { padding: 0 20px; } }
@@ -65,407 +57,350 @@
     /* ─── HEADER ─── */
     header {
       position: fixed; top: 0; left: 0; right: 0; z-index: 1000;
-      background: rgba(10,10,10,0);
-      backdrop-filter: blur(0px);
-      border-bottom: 1px solid rgba(255,255,255,0);
-      transition: background 0.5s var(--ease-apple),
-                  backdrop-filter 0.5s var(--ease-apple),
-                  border-color 0.5s var(--ease-apple);
+      background: rgba(255,255,255,0);
+      transition: background 0.5s var(--ease-apple), box-shadow 0.5s var(--ease-apple);
     }
     header.scrolled {
-      background: rgba(10,10,10,0.88);
+      background: rgba(255,255,255,0.96);
       backdrop-filter: blur(20px) saturate(180%);
-      border-bottom: 1px solid var(--border);
+      box-shadow: rgb(224,226,232) 0px 1px 0px 0px;
     }
 
-    .header-inner { display: flex; align-items: center; justify-content: space-between; height: 70px; }
+    .header-inner { display: flex; align-items: center; justify-content: space-between; height: 68px; }
     .logo {
-      display: flex; align-items: center; gap: 12px;
-      opacity: 0; transform: translateY(-16px);
-      transition: opacity 0.7s var(--ease-smooth) 0.1s,
-                  transform 0.7s var(--ease-smooth) 0.1s;
+      display: flex; align-items: center; gap: 10px;
+      opacity: 0; transform: translateY(-12px);
+      transition: opacity 0.6s var(--ease-smooth) 0.1s, transform 0.6s var(--ease-smooth) 0.1s;
     }
     .logo.visible { opacity: 1; transform: translateY(0); }
     .logo-icon {
-      width: 40px; height: 40px;
-      background: linear-gradient(135deg, var(--accent) 0%, #1a5a8a 100%);
+      width: 36px; height: 36px; border-radius: 10px;
+      background: var(--blue);
       display: flex; align-items: center; justify-content: center;
-      font-family: 'Bebas Neue', sans-serif; font-size: 20px; letter-spacing: 1px;
+      font-family: 'Plus Jakarta Sans', sans-serif;
+      font-size: 14px; font-weight: 800; color: white; letter-spacing: -0.5px;
       transition: transform 0.3s var(--ease-spring), box-shadow 0.3s ease;
     }
     .logo:hover .logo-icon {
-      transform: scale(1.1) rotate(-3deg);
-      box-shadow: 0 0 20px var(--accent-glow);
+      transform: scale(1.08) rotate(-4deg);
+      box-shadow: 0 4px 14px rgba(91,118,254,0.4);
     }
-    .logo-text { font-family: 'Bebas Neue', sans-serif; font-size: 24px; letter-spacing: 3px; }
+    .logo-text { font-family: 'Plus Jakarta Sans', sans-serif; font-size: 15px; font-weight: 700; letter-spacing: -0.3px; color: var(--near-black); }
 
-    nav { display: flex; gap: 40px; }
+    nav { display: flex; align-items: center; gap: 4px; }
     nav a {
-      font-size: 13px; font-weight: 500; letter-spacing: 1.5px; text-transform: uppercase;
-      color: var(--text-muted); transition: color 0.3s ease; position: relative;
-      opacity: 0; transform: translateY(-16px);
+      font-family: 'Plus Jakarta Sans', sans-serif;
+      font-size: 14px; font-weight: 600; padding: 7px 14px; border-radius: 8px;
+      color: var(--slate); transition: color 0.2s ease, background 0.2s ease;
+      opacity: 0; transform: translateY(-12px);
     }
-    nav a.visible { opacity: 1; transform: translateY(0); }
-    nav a::after {
-      content: ''; position: absolute; bottom: -4px; left: 0; width: 0; height: 1px;
-      background: var(--accent); transition: width 0.3s ease;
-    }
-    nav a:hover { color: var(--text); }
-    nav a:hover::after { width: 100%; }
+    nav a.visible { opacity: 1; transform: translateY(0); transition: opacity 0.5s var(--ease-smooth), transform 0.5s var(--ease-smooth), color 0.2s ease, background 0.2s ease; }
+    nav a:hover { color: var(--near-black); background: var(--bg-subtle); }
+    nav a[href$=".pdf"] { border: 1px solid var(--border); color: var(--near-black); }
+    nav a[href$=".pdf"]:hover { background: var(--blue); border-color: var(--blue); color: white; }
 
-    @media (max-width: 900px) { nav { gap: 20px; } nav a { font-size: 11px; letter-spacing: 1px; } }
-    @media (max-width: 600px) { .logo-text { display: none; } nav { gap: 16px; } }
+    @media (max-width: 900px) { nav { gap: 2px; } nav a { font-size: 13px; padding: 6px 10px; } }
+    @media (max-width: 600px) { .logo-text { display: none; } }
 
     /* ─── HERO ─── */
     .hero {
       min-height: 100vh; display: flex; align-items: center; position: relative; overflow: hidden;
-      background: var(--bg-deep);
+      background: var(--bg);
     }
-
-    /* Animated orbs */
-    .hero-orb {
-      position: absolute; border-radius: 50%; pointer-events: none;
-      filter: blur(80px); animation: orbFloat 8s ease-in-out infinite alternate;
+    .hero::before {
+      content: ''; position: absolute; top: -10%; right: -8%; width: 560px; height: 560px;
+      border-radius: 50%;
+      background: radial-gradient(circle, var(--teal-light) 0%, transparent 70%);
+      opacity: 0.6; pointer-events: none;
     }
-    .hero-orb-1 {
-      width: 600px; height: 600px; top: -200px; right: -100px;
-      background: radial-gradient(circle, rgba(58,143,217,0.15) 0%, transparent 70%);
-      animation-duration: 9s;
-    }
-    .hero-orb-2 {
-      width: 400px; height: 400px; bottom: -100px; left: -50px;
-      background: radial-gradient(circle, rgba(201,162,39,0.08) 0%, transparent 70%);
-      animation-duration: 11s; animation-delay: -3s;
-    }
-    .hero-orb-3 {
-      width: 300px; height: 300px; top: 40%; left: 30%;
-      background: radial-gradient(circle, rgba(58,143,217,0.06) 0%, transparent 70%);
-      animation-duration: 13s; animation-delay: -6s;
-    }
-    @keyframes orbFloat {
-      from { transform: translate(0, 0) scale(1); }
-      to   { transform: translate(30px, -40px) scale(1.1); }
+    .hero::after {
+      content: ''; position: absolute; bottom: -15%; left: -5%; width: 400px; height: 400px;
+      border-radius: 50%;
+      background: radial-gradient(circle, var(--rose-light) 0%, transparent 70%);
+      opacity: 0.5; pointer-events: none;
     }
 
     .hero-content {
-      display: grid; grid-template-columns: 1fr 400px; gap: 60px; align-items: center;
+      display: grid; grid-template-columns: 1fr 400px; gap: 64px; align-items: center;
       padding: 120px 0 80px; position: relative; z-index: 1;
     }
-    @media (max-width: 1024px) { .hero-content { grid-template-columns: 1fr; gap: 40px; } }
+    @media (max-width: 1024px) { .hero-content { grid-template-columns: 1fr; gap: 48px; } }
 
     .hero-badge {
-      display: inline-flex; align-items: center; gap: 10px; padding: 8px 16px;
-      background: rgba(58,143,217,0.1); border: 1px solid rgba(58,143,217,0.3);
-      font-size: 11px; font-weight: 600; letter-spacing: 1.5px; text-transform: uppercase;
-      color: var(--accent); margin-bottom: 24px;
-      opacity: 0; transform: translateY(20px);
-      transition: opacity 0.7s var(--ease-smooth), transform 0.7s var(--ease-smooth);
+      display: inline-flex; align-items: center; gap: 8px; padding: 6px 14px;
+      background: rgba(0,180,115,0.1); border: 1px solid rgba(0,180,115,0.3);
+      border-radius: 50px;
+      font-family: 'Plus Jakarta Sans', sans-serif;
+      font-size: 13px; font-weight: 600; color: var(--teal-dark); margin-bottom: 20px;
+      opacity: 0; transform: translateY(16px);
+      transition: opacity 0.6s var(--ease-smooth), transform 0.6s var(--ease-smooth);
     }
     .hero-badge.visible { opacity: 1; transform: translateY(0); }
     .hero-badge::before {
-      content: ''; width: 6px; height: 6px; background: var(--accent); border-radius: 50%;
+      content: ''; width: 7px; height: 7px; background: var(--success); border-radius: 50%;
       animation: pulse 2s infinite;
     }
     @keyframes pulse { 0%, 100% { opacity: 1; } 50% { opacity: 0.4; } }
 
     .hero h1 {
-      font-family: 'Bebas Neue', sans-serif; font-size: clamp(48px, 7vw, 72px);
-      letter-spacing: 2px; line-height: 1.05; margin-bottom: 24px;
-      opacity: 0; transform: translateY(30px);
-      transition: opacity 0.8s var(--ease-smooth) 0.15s,
-                  transform 0.8s var(--ease-smooth) 0.15s;
+      font-family: 'Plus Jakarta Sans', sans-serif;
+      font-size: clamp(38px, 5.5vw, 64px); font-weight: 800;
+      letter-spacing: -2px; line-height: 1.08; margin-bottom: 24px; color: var(--near-black);
+      opacity: 0; transform: translateY(24px);
+      transition: opacity 0.7s var(--ease-smooth) 0.1s, transform 0.7s var(--ease-smooth) 0.1s;
     }
     .hero h1.visible { opacity: 1; transform: translateY(0); }
-    .hero h1 span { color: var(--accent); }
+    .hero h1 span { color: var(--blue); }
 
     .hero-desc {
-      font-size: 16px; font-weight: 300; color: var(--text-muted); max-width: 500px;
-      line-height: 1.8; margin-bottom: 40px;
-      opacity: 0; transform: translateY(30px);
-      transition: opacity 0.8s var(--ease-smooth) 0.25s,
-                  transform 0.8s var(--ease-smooth) 0.25s;
+      font-size: 17px; color: var(--slate); max-width: 500px;
+      line-height: 1.7; margin-bottom: 36px;
+      opacity: 0; transform: translateY(24px);
+      transition: opacity 0.7s var(--ease-smooth) 0.2s, transform 0.7s var(--ease-smooth) 0.2s;
     }
     .hero-desc.visible { opacity: 1; transform: translateY(0); }
 
     .hero-actions {
-      display: flex; gap: 16px; flex-wrap: wrap;
-      opacity: 0; transform: translateY(30px);
-      transition: opacity 0.8s var(--ease-smooth) 0.35s,
-                  transform 0.8s var(--ease-smooth) 0.35s;
+      display: flex; gap: 12px; flex-wrap: wrap;
+      opacity: 0; transform: translateY(24px);
+      transition: opacity 0.7s var(--ease-smooth) 0.3s, transform 0.7s var(--ease-smooth) 0.3s;
     }
     .hero-actions.visible { opacity: 1; transform: translateY(0); }
 
     .btn {
-      display: inline-flex; align-items: center; gap: 10px; padding: 14px 28px;
-      font-size: 12px; font-weight: 600; letter-spacing: 1.5px; text-transform: uppercase;
-      border: 1px solid var(--border-light); background: transparent; color: var(--text);
+      display: inline-flex; align-items: center; gap: 8px; padding: 12px 24px;
+      font-family: 'Plus Jakarta Sans', sans-serif;
+      font-size: 15px; font-weight: 700; border-radius: 8px;
+      border: 1px solid var(--border); background: transparent; color: var(--near-black);
       cursor: pointer;
-      transition: background 0.3s ease, border-color 0.3s ease,
-                  box-shadow 0.3s ease, transform 0.2s var(--ease-spring);
+      transition: background 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease, transform 0.2s var(--ease-spring);
     }
-    .btn:hover {
-      background: rgba(255,255,255,0.05); border-color: var(--text-muted);
-      transform: translateY(-2px);
-    }
+    .btn:hover { background: var(--bg-subtle); transform: translateY(-1px); }
     .btn:active { transform: translateY(0) scale(0.98); }
-    .btn-primary { background: var(--accent); border-color: var(--accent); }
-    .btn-primary:hover {
-      background: #4a9fe9; border-color: #4a9fe9;
-      box-shadow: 0 0 30px var(--accent-glow), 0 8px 24px rgba(58,143,217,0.25);
-    }
+    .btn-primary { background: var(--blue); border-color: var(--blue); color: white; }
+    .btn-primary:hover { background: var(--blue-pressed); border-color: var(--blue-pressed); box-shadow: 0 4px 16px rgba(91,118,254,0.35); }
+    .btn-white { background: white; border-color: white; color: var(--blue); }
+    .btn-white:hover { background: rgba(255,255,255,0.9); box-shadow: 0 4px 16px rgba(0,0,0,0.15); }
 
     /* ─── PROFILE CARD ─── */
     .profile-card {
-      background: var(--bg-card); border: 1px solid var(--border); padding: 32px;
+      background: white; border-radius: 24px;
+      box-shadow: rgb(224,226,232) 0px 0px 0px 1px, 0 8px 40px rgba(0,0,0,0.06);
+      padding: 32px;
       opacity: 0; transform: translateX(40px) scale(0.97);
-      transition: opacity 0.9s var(--ease-smooth) 0.2s,
-                  transform 0.9s var(--ease-smooth) 0.2s,
-                  box-shadow 0.5s ease, border-color 0.3s ease;
+      transition: opacity 0.8s var(--ease-smooth) 0.2s, transform 0.8s var(--ease-smooth) 0.2s, box-shadow 0.3s ease;
     }
     .profile-card.visible { opacity: 1; transform: translateX(0) scale(1); }
-    .profile-card:hover {
-      border-color: rgba(58,143,217,0.3);
-      box-shadow: 0 20px 60px rgba(0,0,0,0.5), 0 0 40px rgba(58,143,217,0.05);
-    }
+    .profile-card:hover { box-shadow: rgb(224,226,232) 0px 0px 0px 1px, 0 20px 60px rgba(91,118,254,0.1); }
     .profile-header {
-      display: flex; gap: 24px; align-items: center; margin-bottom: 28px;
-      padding-bottom: 28px; border-bottom: 1px solid var(--border);
+      display: flex; gap: 20px; align-items: center; margin-bottom: 24px;
+      padding-bottom: 24px; border-bottom: 1px solid var(--ring);
     }
     .profile-avatar {
-      width: 120px; height: 120px; object-fit: cover; filter: grayscale(20%);
-      transition: filter 0.4s ease, transform 0.4s var(--ease-spring);
+      width: 80px; height: 80px; object-fit: cover;
+      border-radius: 50%; box-shadow: rgb(224,226,232) 0px 0px 0px 3px;
+      transition: transform 0.3s var(--ease-spring);
     }
-    .profile-card:hover .profile-avatar { filter: grayscale(0%); transform: scale(1.03); }
-    .profile-info h3 { font-family: 'Bebas Neue', sans-serif; font-size: 22px; letter-spacing: 1px; margin-bottom: 4px; }
-    .profile-info p { font-size: 13px; color: var(--text-dim); line-height: 1.5; }
-    .profile-meta { display: flex; flex-direction: column; gap: 16px; }
+    .profile-card:hover .profile-avatar { transform: scale(1.04); }
+    .profile-info h3 { font-family: 'Plus Jakarta Sans', sans-serif; font-size: 17px; font-weight: 700; letter-spacing: -0.5px; margin-bottom: 4px; }
+    .profile-info p { font-size: 13px; color: var(--slate); line-height: 1.5; }
+    .profile-meta { display: flex; flex-direction: column; }
     .meta-item {
-      display: flex; justify-content: space-between; align-items: center;
-      padding-bottom: 16px; border-bottom: 1px solid var(--border);
+      display: flex; justify-content: space-between; align-items: flex-start; gap: 12px;
+      padding: 14px 0; border-bottom: 1px solid var(--ring);
     }
     .meta-item:last-child { border-bottom: none; padding-bottom: 0; }
-    .meta-label { font-size: 11px; font-weight: 600; letter-spacing: 1px; text-transform: uppercase; color: var(--text-dim); }
-    .meta-value { font-size: 13px; color: var(--text-muted); text-align: right; }
+    .meta-label { font-family: 'Plus Jakarta Sans', sans-serif; font-size: 11px; font-weight: 700; letter-spacing: 0.5px; text-transform: uppercase; color: var(--placeholder); white-space: nowrap; }
+    .meta-value { font-size: 13px; color: var(--slate); text-align: right; line-height: 1.4; }
 
     /* ─── SECTIONS ─── */
-    .section { padding: 80px 0; border-top: 1px solid var(--border); }
+    .section { padding: 80px 0; border-top: 1px solid var(--ring); }
     .section-header { margin-bottom: 48px; }
 
-    /* Scroll-reveal base class */
     .reveal {
-      opacity: 0; transform: translateY(40px);
-      transition: opacity 0.8s var(--ease-smooth), transform 0.8s var(--ease-smooth);
+      opacity: 0; transform: translateY(32px);
+      transition: opacity 0.7s var(--ease-smooth), transform 0.7s var(--ease-smooth);
     }
     .reveal.visible { opacity: 1; transform: translateY(0); }
     .reveal-left {
-      opacity: 0; transform: translateX(-50px);
-      transition: opacity 0.8s var(--ease-smooth), transform 0.8s var(--ease-smooth);
+      opacity: 0; transform: translateX(-40px);
+      transition: opacity 0.7s var(--ease-smooth), transform 0.7s var(--ease-smooth);
     }
     .reveal-left.visible { opacity: 1; transform: translateX(0); }
     .reveal-right {
-      opacity: 0; transform: translateX(50px);
-      transition: opacity 0.8s var(--ease-smooth), transform 0.8s var(--ease-smooth);
+      opacity: 0; transform: translateX(40px);
+      transition: opacity 0.7s var(--ease-smooth), transform 0.7s var(--ease-smooth);
     }
     .reveal-right.visible { opacity: 1; transform: translateX(0); }
 
-    /* Stagger children */
     .stagger-children > * {
-      opacity: 0; transform: translateY(30px);
-      transition: opacity 0.6s var(--ease-smooth), transform 0.6s var(--ease-smooth);
+      opacity: 0; transform: translateY(24px);
+      transition: opacity 0.5s var(--ease-smooth), transform 0.5s var(--ease-smooth);
     }
     .stagger-children.visible > *:nth-child(1) { opacity:1; transform:translateY(0); transition-delay:0s; }
-    .stagger-children.visible > *:nth-child(2) { opacity:1; transform:translateY(0); transition-delay:0.08s; }
-    .stagger-children.visible > *:nth-child(3) { opacity:1; transform:translateY(0); transition-delay:0.16s; }
-    .stagger-children.visible > *:nth-child(4) { opacity:1; transform:translateY(0); transition-delay:0.24s; }
-    .stagger-children.visible > *:nth-child(5) { opacity:1; transform:translateY(0); transition-delay:0.32s; }
-    .stagger-children.visible > *:nth-child(6) { opacity:1; transform:translateY(0); transition-delay:0.40s; }
-    .stagger-children.visible > *:nth-child(7) { opacity:1; transform:translateY(0); transition-delay:0.48s; }
-    .stagger-children.visible > *:nth-child(8) { opacity:1; transform:translateY(0); transition-delay:0.56s; }
+    .stagger-children.visible > *:nth-child(2) { opacity:1; transform:translateY(0); transition-delay:0.07s; }
+    .stagger-children.visible > *:nth-child(3) { opacity:1; transform:translateY(0); transition-delay:0.14s; }
+    .stagger-children.visible > *:nth-child(4) { opacity:1; transform:translateY(0); transition-delay:0.21s; }
+    .stagger-children.visible > *:nth-child(5) { opacity:1; transform:translateY(0); transition-delay:0.28s; }
+    .stagger-children.visible > *:nth-child(6) { opacity:1; transform:translateY(0); transition-delay:0.35s; }
+    .stagger-children.visible > *:nth-child(7) { opacity:1; transform:translateY(0); transition-delay:0.42s; }
+    .stagger-children.visible > *:nth-child(8) { opacity:1; transform:translateY(0); transition-delay:0.49s; }
 
     .section-title {
-      font-family: 'Bebas Neue', sans-serif; font-size: 14px; letter-spacing: 3px;
-      text-transform: uppercase; color: var(--accent); margin-bottom: 12px;
+      font-family: 'Plus Jakarta Sans', sans-serif;
+      font-size: 12px; font-weight: 700; letter-spacing: 1px; text-transform: uppercase;
+      color: var(--blue); margin-bottom: 12px;
     }
-    .section-heading { font-family: 'Bebas Neue', sans-serif; font-size: 42px; letter-spacing: 2px; }
-    .section-desc {
-      font-size: 16px; color: var(--text-muted); max-width: 600px;
-      margin-top: 16px; line-height: 1.7;
+    .section-heading {
+      font-family: 'Plus Jakarta Sans', sans-serif;
+      font-size: clamp(28px, 4vw, 48px); font-weight: 800; letter-spacing: -1.5px;
+      color: var(--near-black); line-height: 1.1;
     }
+    .section-desc { font-size: 17px; color: var(--slate); max-width: 600px; margin-top: 16px; line-height: 1.7; }
 
     /* ─── SEARCH / FILTERS ─── */
     .controls {
       display: flex; justify-content: space-between; align-items: center;
-      gap: 20px; margin-bottom: 40px; flex-wrap: wrap;
+      gap: 16px; margin-bottom: 32px; flex-wrap: wrap;
     }
     .search-box {
-      display: flex; align-items: center; gap: 12px; padding: 12px 20px;
-      background: var(--bg-card); border: 1px solid var(--border); min-width: 320px;
-      transition: border-color 0.3s ease, box-shadow 0.3s ease;
+      display: flex; align-items: center; gap: 10px; padding: 10px 16px;
+      background: white; border: 1px solid var(--border); border-radius: 8px; min-width: 280px;
+      transition: border-color 0.2s ease, box-shadow 0.2s ease;
     }
-    .search-box:focus-within {
-      border-color: rgba(58,143,217,0.5);
-      box-shadow: 0 0 0 3px rgba(58,143,217,0.1);
-    }
-    .search-box svg { width: 16px; height: 16px; color: var(--text-dim); }
-    .search-box input { flex: 1; background: transparent; border: none; outline: none; color: var(--text); font-family: 'Barlow', sans-serif; font-size: 13px; }
-    .search-box input::placeholder { color: var(--text-dim); }
+    .search-box:focus-within { border-color: var(--blue); box-shadow: 0 0 0 3px rgba(91,118,254,0.12); }
+    .search-box svg { width: 16px; height: 16px; color: var(--placeholder); flex-shrink: 0; }
+    .search-box input { flex: 1; background: transparent; border: none; outline: none; color: var(--near-black); font-family: 'Noto Sans', sans-serif; font-size: 14px; }
+    .search-box input::placeholder { color: var(--placeholder); }
 
-    .filter-tabs { display: flex; border: 1px solid var(--border); }
+    .filter-tabs { display: flex; gap: 4px; }
     .filter-tabs button {
-      padding: 12px 24px; background: transparent; border: none; color: var(--text-dim);
-      font-family: 'Barlow', sans-serif; font-size: 12px; font-weight: 600; letter-spacing: 1px;
-      text-transform: uppercase; cursor: pointer;
-      transition: color 0.3s ease, background 0.3s ease; border-right: 1px solid var(--border);
+      padding: 8px 18px; background: transparent; border: 1px solid var(--border); border-radius: 8px;
+      color: var(--slate); font-family: 'Plus Jakarta Sans', sans-serif;
+      font-size: 13px; font-weight: 600; cursor: pointer; transition: all 0.2s ease;
     }
-    .filter-tabs button:last-child { border-right: none; }
-    .filter-tabs button:hover { color: var(--text-muted); background: rgba(255,255,255,0.02); }
-    .filter-tabs button.active { color: var(--text); background: var(--accent); }
+    .filter-tabs button:hover { background: var(--bg-subtle); color: var(--near-black); }
+    .filter-tabs button.active { background: var(--blue); border-color: var(--blue); color: white; }
 
     @media (max-width: 768px) { .search-box { min-width: 100%; } .controls { flex-direction: column; align-items: stretch; } }
 
     /* ─── DASHBOARD GRID ─── */
     .dashboard-grid {
       display: grid; grid-template-columns: repeat(4, 1fr);
-      gap: 2px; background: var(--border);
+      gap: 16px; background: transparent;
     }
     @media (max-width: 1200px) { .dashboard-grid { grid-template-columns: repeat(3, 1fr); } }
     @media (max-width: 900px)  { .dashboard-grid { grid-template-columns: repeat(2, 1fr); } }
     @media (max-width: 600px)  { .dashboard-grid { grid-template-columns: 1fr; } }
 
     .dashboard-card {
-      background: var(--bg-card); display: flex; flex-direction: column;
-      transition: background 0.3s ease, transform 0.4s var(--ease-spring);
+      background: white; border-radius: 16px;
+      box-shadow: rgb(224,226,232) 0px 0px 0px 1px;
+      display: flex; flex-direction: column; overflow: hidden;
+      transition: box-shadow 0.3s ease, transform 0.3s var(--ease-spring);
       cursor: pointer;
-      opacity: 0; transform: translateY(30px) scale(0.97);
+      opacity: 0; transform: translateY(24px) scale(0.98);
     }
-    .dashboard-card.card-visible {
-      opacity: 1; transform: translateY(0) scale(1);
-    }
+    .dashboard-card.card-visible { opacity: 1; transform: translateY(0) scale(1); }
     .dashboard-card:hover {
-      background: var(--bg-card-hover);
-      transform: translateY(-4px) scale(1.01);
-      z-index: 2;
-      box-shadow: 0 20px 40px rgba(0,0,0,0.5);
+      box-shadow: rgb(224,226,232) 0px 0px 0px 1px, 0 12px 40px rgba(91,118,254,0.12);
+      transform: translateY(-4px);
     }
-    .card-image { position: relative; aspect-ratio: 16/10; overflow: hidden; background: #000; }
+    .card-image { position: relative; aspect-ratio: 16/10; overflow: hidden; background: var(--bg-subtle); }
     .card-image img {
       width: 100%; height: 100%; object-fit: cover;
-      transition: transform 0.6s var(--ease-apple), filter 0.4s ease;
-      filter: saturate(0.9);
+      transition: transform 0.5s var(--ease-apple);
     }
-    .dashboard-card:hover .card-image img { transform: scale(1.07); filter: saturate(1.1); }
+    .dashboard-card:hover .card-image img { transform: scale(1.05); }
     .card-image::after {
       content: ''; position: absolute; inset: 0;
-      background: linear-gradient(180deg, transparent 40%, rgba(0,0,0,0.75) 100%);
+      background: linear-gradient(180deg, transparent 50%, rgba(0,0,0,0.4) 100%);
       pointer-events: none;
     }
-    .card-tags { position: absolute; bottom: 12px; left: 12px; display: flex; gap: 6px; z-index: 1; }
+    .card-tags { position: absolute; bottom: 10px; left: 10px; display: flex; gap: 6px; z-index: 1; }
     .tag {
-      padding: 4px 10px; background: rgba(0,0,0,0.6); backdrop-filter: blur(4px);
-      font-size: 10px; font-weight: 600; letter-spacing: 0.5px; text-transform: uppercase;
-      color: rgba(255,255,255,0.8);
+      padding: 4px 10px; background: rgba(255,255,255,0.9); border-radius: 20px;
+      font-family: 'Plus Jakarta Sans', sans-serif;
+      font-size: 11px; font-weight: 700; color: var(--near-black);
+      backdrop-filter: blur(4px);
     }
-    .tag-live { background: rgba(58,143,217,0.85); }
-    .card-body { padding: 20px; flex: 1; display: flex; flex-direction: column; }
-    .card-body h4 { font-family: 'Bebas Neue', sans-serif; font-size: 18px; letter-spacing: 1px; margin-bottom: 8px; }
-    .card-body p { font-size: 13px; color: var(--text-dim); line-height: 1.6; flex: 1; margin-bottom: 16px; }
+    .tag-live { background: var(--blue); color: white; }
+    .card-body { padding: 16px; flex: 1; display: flex; flex-direction: column; }
+    .card-body h4 { font-family: 'Plus Jakarta Sans', sans-serif; font-size: 14px; font-weight: 700; letter-spacing: -0.3px; margin-bottom: 6px; color: var(--near-black); }
+    .card-body p { font-size: 12px; color: var(--slate); line-height: 1.55; flex: 1; margin-bottom: 14px; }
     .card-actions { display: flex; gap: 8px; }
     .card-btn {
-      flex: 1; padding: 10px 16px; background: transparent; border: 1px solid var(--border-light);
-      color: var(--text-muted); font-family: 'Barlow', sans-serif; font-size: 11px;
-      font-weight: 600; letter-spacing: 1px; text-transform: uppercase; cursor: pointer;
-      transition: border-color 0.3s ease, color 0.3s ease, background 0.3s ease,
-                  transform 0.2s var(--ease-spring);
-      text-align: center;
+      flex: 1; padding: 8px 12px; background: transparent; border: 1px solid var(--border); border-radius: 8px;
+      color: var(--near-black); font-family: 'Plus Jakarta Sans', sans-serif;
+      font-size: 12px; font-weight: 600; cursor: pointer; transition: all 0.2s ease; text-align: center;
     }
-    .card-btn:hover { border-color: var(--text-muted); color: var(--text); transform: translateY(-1px); }
-    .card-btn-primary { background: var(--accent); border-color: var(--accent); color: var(--text); }
-    .card-btn-primary:hover { background: #4a9fe9; border-color: #4a9fe9; box-shadow: 0 4px 14px rgba(58,143,217,0.35); }
+    .card-btn:hover { background: var(--bg-subtle); transform: translateY(-1px); }
+    .card-btn-primary { background: var(--blue); border-color: var(--blue); color: white; }
+    .card-btn-primary:hover { background: var(--blue-pressed); border-color: var(--blue-pressed); }
 
     /* ─── SQL SECTION ─── */
-    .sql-showcase {
-      background: linear-gradient(135deg, rgba(58,143,217,0.04) 0%, transparent 50%), var(--bg-deep);
-    }
-    .showcase-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 40px; align-items: start; }
+    .sql-showcase { background: #fdf6f0; }
+    .showcase-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 48px; align-items: start; }
     @media (max-width: 1024px) { .showcase-grid { grid-template-columns: 1fr; } }
-    .showcase-content h3 { font-family: 'Bebas Neue', sans-serif; font-size: 28px; letter-spacing: 1px; margin-bottom: 20px; }
-    .showcase-content p { font-size: 15px; color: var(--text-muted); line-height: 1.8; margin-bottom: 16px; }
+    .showcase-content h3 { font-family: 'Plus Jakarta Sans', sans-serif; font-size: 22px; font-weight: 800; letter-spacing: -0.5px; margin-bottom: 16px; color: var(--near-black); }
+    .showcase-content p { font-size: 15px; color: var(--slate); line-height: 1.75; margin-bottom: 16px; }
 
-    .showcase-stats { display: grid; grid-template-columns: repeat(3, 1fr); gap: 16px; margin: 32px 0; }
+    .showcase-stats { display: grid; grid-template-columns: repeat(3, 1fr); gap: 12px; margin: 28px 0; }
     .stat-box {
-      background: var(--bg-card); border: 1px solid var(--border); padding: 20px; text-align: center;
-      transition: border-color 0.3s ease, transform 0.3s var(--ease-spring), box-shadow 0.3s ease;
+      background: white; border-radius: 16px;
+      box-shadow: rgb(224,226,232) 0px 0px 0px 1px;
+      padding: 20px; text-align: center;
+      transition: box-shadow 0.3s ease, transform 0.3s var(--ease-spring);
     }
     .stat-box:hover {
-      border-color: rgba(58,143,217,0.4);
-      transform: translateY(-4px);
-      box-shadow: 0 10px 30px rgba(0,0,0,0.3), 0 0 20px rgba(58,143,217,0.08);
+      box-shadow: rgb(224,226,232) 0px 0px 0px 1px, 0 8px 24px rgba(91,118,254,0.1);
+      transform: translateY(-3px);
     }
     .stat-value {
-      font-family: 'Bebas Neue', sans-serif; font-size: 36px; color: var(--accent);
-      letter-spacing: 1px;
-      /* Counter animation handled via JS */
-      display: block;
+      font-family: 'Plus Jakarta Sans', sans-serif;
+      font-size: 36px; font-weight: 800; color: var(--blue); letter-spacing: -1px; display: block;
     }
-    .stat-label { font-size: 11px; font-weight: 600; letter-spacing: 1px; text-transform: uppercase; color: var(--text-dim); margin-top: 4px; }
+    .stat-label { font-family: 'Plus Jakarta Sans', sans-serif; font-size: 11px; font-weight: 600; color: var(--slate); margin-top: 4px; }
 
     .tech-tags { display: flex; flex-wrap: wrap; gap: 8px; margin-top: 24px; }
     .tech-tag {
-      padding: 8px 16px; background: var(--bg-card); border: 1px solid var(--border);
-      font-size: 11px; font-weight: 600; letter-spacing: 1px; text-transform: uppercase;
-      color: var(--text-muted);
-      transition: border-color 0.3s ease, color 0.3s ease, transform 0.2s var(--ease-spring);
+      padding: 6px 14px; background: rgba(91,118,254,0.08); border: 1px solid rgba(91,118,254,0.2);
+      border-radius: 20px; font-family: 'Plus Jakarta Sans', sans-serif;
+      font-size: 12px; font-weight: 600; color: var(--blue); transition: background 0.2s ease;
     }
-    .tech-tag:hover { border-color: var(--accent); color: var(--accent); transform: translateY(-2px); }
+    .tech-tag:hover { background: rgba(91,118,254,0.16); }
 
     /* SQL Toggle */
-    .sql-toggle { display: flex; border: 1px solid var(--border); margin-bottom: 32px; width: fit-content; }
+    .sql-toggle { display: flex; gap: 4px; margin-bottom: 32px; width: fit-content; }
     .sql-toggle button {
-      padding: 14px 28px; background: transparent; border: none; color: var(--text-dim);
-      font-family: 'Barlow', sans-serif; font-size: 12px; font-weight: 600; letter-spacing: 1px;
-      text-transform: uppercase; cursor: pointer;
-      transition: color 0.3s ease, background 0.3s ease; border-right: 1px solid var(--border);
-      position: relative;
+      padding: 10px 24px; background: white; border: 1px solid var(--border); border-radius: 8px;
+      color: var(--slate); font-family: 'Plus Jakarta Sans', sans-serif;
+      font-size: 14px; font-weight: 600; cursor: pointer; transition: all 0.2s ease;
     }
-    .sql-toggle button:last-child { border-right: none; }
-    .sql-toggle button:hover { color: var(--text-muted); background: rgba(255,255,255,0.02); }
-    .sql-toggle button.active { color: var(--text); background: var(--accent); }
-    .sql-toggle button.active::after {
-      content: ''; position: absolute; bottom: -1px; left: 50%; transform: translateX(-50%);
-      width: 0; height: 0; border-left: 6px solid transparent; border-right: 6px solid transparent;
-      border-top: 6px solid var(--accent);
-    }
+    .sql-toggle button:hover { color: var(--near-black); background: var(--bg-subtle); }
+    .sql-toggle button.active { color: white; background: var(--blue); border-color: var(--blue); }
+    .sql-toggle button.active::after { display: none; }
 
     .sql-panel { display: none; }
-    .sql-panel.active {
-      display: block;
-      animation: panelFadeIn 0.5s var(--ease-smooth);
-    }
+    .sql-panel.active { display: block; animation: panelFadeIn 0.4s var(--ease-smooth); }
     @keyframes panelFadeIn {
-      from { opacity: 0; transform: translateY(16px); }
+      from { opacity: 0; transform: translateY(12px); }
       to   { opacity: 1; transform: translateY(0); }
     }
 
-    .code-container {
-      background: var(--bg-code); border: 1px solid var(--border); overflow: hidden;
-      transition: border-color 0.3s ease, box-shadow 0.3s ease;
-    }
-    .code-container:hover {
-      border-color: rgba(58,143,217,0.25);
-      box-shadow: 0 0 40px rgba(58,143,217,0.05);
-    }
+    .code-container { background: #1e1e2e; border-radius: 16px; overflow: hidden; box-shadow: 0 8px 40px rgba(0,0,0,0.15); }
     .code-header {
       display: flex; justify-content: space-between; align-items: center;
-      padding: 12px 20px; background: rgba(255,255,255,0.02); border-bottom: 1px solid var(--border);
+      padding: 12px 20px; background: rgba(255,255,255,0.05); border-bottom: 1px solid rgba(255,255,255,0.08);
     }
-    .code-title { font-family: 'JetBrains Mono', monospace; font-size: 12px; color: var(--text-muted); }
+    .code-title { font-family: 'JetBrains Mono', monospace; font-size: 12px; color: rgba(255,255,255,0.55); }
     .code-lang {
       font-size: 10px; font-weight: 600; letter-spacing: 1px; text-transform: uppercase;
-      color: var(--accent); padding: 4px 10px;
-      background: rgba(58,143,217,0.1); border: 1px solid rgba(58,143,217,0.3);
+      color: var(--blue); padding: 4px 10px;
+      background: rgba(91,118,254,0.15); border: 1px solid rgba(91,118,254,0.3); border-radius: 4px;
     }
     .code-block { padding: 20px; overflow-x: auto; max-height: 520px; overflow-y: auto; }
-    .code-block pre { font-family: 'JetBrains Mono', monospace; font-size: 11px; line-height: 1.6; color: #e6edf3; margin: 0; white-space: pre; }
+    .code-block pre { font-family: 'JetBrains Mono', monospace; font-size: 11px; line-height: 1.65; color: #e6edf3; margin: 0; white-space: pre; }
     .code-block .keyword  { color: var(--code-keyword); }
     .code-block .function { color: var(--code-function); }
     .code-block .string   { color: var(--code-string); }
@@ -474,177 +409,152 @@
 
     /* ─── PROCESS STEPS ─── */
     .process-section { margin-top: 60px; }
-    .process-grid { display: grid; grid-template-columns: repeat(4, 1fr); gap: 2px; background: var(--border); }
+    .process-grid { display: grid; grid-template-columns: repeat(4, 1fr); gap: 16px; background: transparent; }
     @media (max-width: 900px) { .process-grid { grid-template-columns: repeat(2, 1fr); } }
     @media (max-width: 500px) { .process-grid { grid-template-columns: 1fr; } }
     .process-step {
-      background: var(--bg-card); padding: 32px 24px; position: relative;
-      transition: background 0.3s ease, transform 0.4s var(--ease-spring);
+      background: white; border-radius: 16px;
+      box-shadow: rgb(224,226,232) 0px 0px 0px 1px;
+      padding: 28px 24px; position: relative;
+      transition: box-shadow 0.3s ease, transform 0.3s var(--ease-spring);
     }
-    .process-step:hover { background: var(--bg-card-hover); transform: translateY(-4px); }
+    .process-step:hover { box-shadow: rgb(224,226,232) 0px 0px 0px 1px, 0 8px 24px rgba(91,118,254,0.1); transform: translateY(-4px); }
     .step-number {
-      font-family: 'Bebas Neue', sans-serif; font-size: 48px;
-      color: rgba(58,143,217,0.15); position: absolute; top: 16px; right: 20px;
+      font-family: 'Plus Jakarta Sans', sans-serif; font-size: 52px; font-weight: 800;
+      color: rgba(91,118,254,0.1); position: absolute; top: 12px; right: 16px; line-height: 1;
       transition: color 0.3s ease;
     }
-    .process-step:hover .step-number { color: rgba(58,143,217,0.3); }
-    .process-step h4 { font-family: 'Bebas Neue', sans-serif; font-size: 18px; letter-spacing: 1px; margin-bottom: 12px; color: var(--accent); }
-    .process-step p { font-size: 13px; color: var(--text-dim); line-height: 1.6; }
+    .process-step:hover .step-number { color: rgba(91,118,254,0.2); }
+    .process-step h4 { font-family: 'Plus Jakarta Sans', sans-serif; font-size: 14px; font-weight: 700; margin-bottom: 10px; color: var(--blue); }
+    .process-step p { font-size: 13px; color: var(--slate); line-height: 1.6; }
 
     /* ─── CONTACT ─── */
-    .contact-grid { display: grid; grid-template-columns: repeat(3, 1fr); gap: 2px; background: var(--border); }
+    .contact-grid { display: grid; grid-template-columns: repeat(3, 1fr); gap: 16px; }
     @media (max-width: 768px) { .contact-grid { grid-template-columns: 1fr; } }
     .contact-card {
-      background: var(--bg-card); padding: 40px;
-      transition: background 0.3s ease, transform 0.4s var(--ease-spring), box-shadow 0.3s ease;
+      background: white; border-radius: 20px;
+      box-shadow: rgb(224,226,232) 0px 0px 0px 1px;
+      padding: 36px; text-align: center;
+      transition: box-shadow 0.3s ease, transform 0.3s var(--ease-spring);
     }
-    .contact-card:hover {
-      background: var(--bg-card-hover); transform: translateY(-6px);
-      box-shadow: 0 20px 40px rgba(0,0,0,0.4);
-    }
-    .contact-icon {
-      font-size: 28px; margin-bottom: 20px; display: block;
-      transition: transform 0.3s var(--ease-spring);
-    }
-    .contact-card:hover .contact-icon { transform: scale(1.2) rotate(-5deg); }
-    .contact-card h4 { font-family: 'Bebas Neue', sans-serif; font-size: 20px; letter-spacing: 1px; margin-bottom: 12px; }
-    .contact-card p { font-size: 13px; color: var(--text-dim); line-height: 1.6; margin-bottom: 24px; }
+    .contact-card:hover { box-shadow: rgb(224,226,232) 0px 0px 0px 1px, 0 12px 40px rgba(91,118,254,0.1); transform: translateY(-6px); }
+    .contact-icon { font-size: 30px; margin-bottom: 16px; display: block; transition: transform 0.3s var(--ease-spring); }
+    .contact-card:hover .contact-icon { transform: scale(1.15) rotate(-5deg); }
+    .contact-card h4 { font-family: 'Plus Jakarta Sans', sans-serif; font-size: 17px; font-weight: 700; margin-bottom: 10px; color: var(--near-black); letter-spacing: -0.5px; }
+    .contact-card p { font-size: 14px; color: var(--slate); line-height: 1.6; margin-bottom: 24px; }
 
     /* ─── FOOTER ─── */
-    footer { padding: 40px 0; border-top: 1px solid var(--border); }
-    .footer-inner { display: flex; justify-content: space-between; align-items: center; flex-wrap: wrap; gap: 20px; }
-    .footer-copy { font-size: 12px; color: var(--text-dim); }
-    .footer-links { display: flex; gap: 32px; }
-    .footer-links a {
-      font-size: 11px; font-weight: 500; letter-spacing: 1px; text-transform: uppercase;
-      color: var(--text-dim); transition: color 0.3s ease;
-    }
-    .footer-links a:hover { color: var(--text); }
+    footer { padding: 36px 0; border-top: 1px solid var(--ring); background: white; }
+    .footer-inner { display: flex; justify-content: space-between; align-items: center; flex-wrap: wrap; gap: 16px; }
+    .footer-copy { font-size: 13px; color: var(--slate); }
+    .footer-links { display: flex; gap: 24px; }
+    .footer-links a { font-family: 'Plus Jakarta Sans', sans-serif; font-size: 13px; font-weight: 500; color: var(--slate); transition: color 0.2s ease; }
+    .footer-links a:hover { color: var(--near-black); }
     .back-to-top {
-      display: flex; align-items: center; gap: 8px; font-size: 11px; font-weight: 500;
-      letter-spacing: 1px; text-transform: uppercase; color: var(--text-dim);
-      cursor: pointer; transition: color 0.3s ease, transform 0.3s var(--ease-spring);
+      display: flex; align-items: center; gap: 6px;
+      font-family: 'Plus Jakarta Sans', sans-serif; font-size: 13px; font-weight: 600; color: var(--blue);
+      cursor: pointer; transition: transform 0.2s ease;
     }
-    .back-to-top:hover { color: var(--text); transform: translateY(-2px); }
+    .back-to-top:hover { transform: translateY(-2px); }
 
     /* ─── MODAL ─── */
     .modal-overlay {
-      position: fixed; inset: 0; background: rgba(0,0,0,0); backdrop-filter: blur(0px);
+      position: fixed; inset: 0; background: rgba(28,28,30,0); backdrop-filter: blur(0px);
       display: none; align-items: center; justify-content: center; padding: 40px; z-index: 2000;
-      transition: background 0.4s ease, backdrop-filter 0.4s ease;
+      transition: background 0.35s ease, backdrop-filter 0.35s ease;
     }
-    .modal-overlay.open {
-      background: rgba(0,0,0,0.88); backdrop-filter: blur(20px) saturate(180%);
-    }
+    .modal-overlay.open { background: rgba(28,28,30,0.65); backdrop-filter: blur(12px); }
     .modal {
-      width: 100%; max-width: 900px; background: var(--bg-card); border: 1px solid var(--border);
-      transform: scale(0.92) translateY(20px); opacity: 0;
-      transition: transform 0.5s var(--ease-smooth), opacity 0.5s var(--ease-smooth);
+      width: 100%; max-width: 860px; background: white; border-radius: 24px;
+      box-shadow: 0 32px 80px rgba(0,0,0,0.18);
+      transform: scale(0.94) translateY(16px); opacity: 0;
+      transition: transform 0.4s var(--ease-smooth), opacity 0.4s var(--ease-smooth);
+      overflow: hidden;
     }
     .modal-overlay.open .modal { transform: scale(1) translateY(0); opacity: 1; }
     .modal-header {
       display: flex; justify-content: space-between; align-items: center;
-      padding: 20px 24px; border-bottom: 1px solid var(--border);
+      padding: 20px 24px; border-bottom: 1px solid var(--ring);
     }
-    .modal-title { font-family: 'Bebas Neue', sans-serif; font-size: 20px; letter-spacing: 1px; }
-    .modal-meta { font-size: 12px; color: var(--text-dim); }
+    .modal-title { font-family: 'Plus Jakarta Sans', sans-serif; font-size: 17px; font-weight: 700; letter-spacing: -0.5px; color: var(--near-black); }
+    .modal-meta { font-size: 13px; color: var(--slate); margin-top: 3px; }
     .modal-close {
-      width: 40px; height: 40px; display: flex; align-items: center; justify-content: center;
-      background: transparent; border: 1px solid var(--border); color: var(--text-muted);
-      font-size: 18px; cursor: pointer;
-      transition: background 0.3s ease, color 0.3s ease, transform 0.3s var(--ease-spring);
+      width: 36px; height: 36px; display: flex; align-items: center; justify-content: center;
+      background: var(--bg-subtle); border: 1px solid var(--border); border-radius: 50%;
+      color: var(--slate); font-size: 16px; cursor: pointer; transition: all 0.2s ease;
     }
-    .modal-close:hover { background: rgba(255,255,255,0.08); color: var(--text); transform: rotate(90deg); }
+    .modal-close:hover { background: var(--ring); color: var(--near-black); transform: rotate(90deg); }
     .modal-body { padding: 24px; }
-    .modal-image { width: 100%; margin-bottom: 20px; border: 1px solid var(--border); overflow: hidden; }
+    .modal-image { width: 100%; margin-bottom: 20px; border-radius: 12px; overflow: hidden; box-shadow: rgb(224,226,232) 0px 0px 0px 1px; }
     .modal-image img { width: 100%; display: block; transition: transform 0.4s var(--ease-smooth); }
     .modal-image:hover img { transform: scale(1.02); }
     .modal-actions { display: flex; gap: 12px; }
 
     /* ─── FEATURED ─── */
     .featured-highlight {
-      background: linear-gradient(135deg, rgba(58,143,217,0.1) 0%, rgba(201,162,39,0.06) 100%);
-      border: 1px solid rgba(58,143,217,0.25);
-      padding: 32px; margin-bottom: 40px;
-      transition: border-color 0.4s ease, box-shadow 0.4s ease;
+      background: rgba(91,118,254,0.06); border: 1px solid rgba(91,118,254,0.2);
+      border-radius: 16px; padding: 20px 28px; margin-bottom: 32px; transition: box-shadow 0.3s ease;
     }
-    .featured-highlight:hover {
-      border-color: rgba(58,143,217,0.4);
-      box-shadow: 0 0 60px rgba(58,143,217,0.07);
-    }
-    .featured-highlight h3 {
-      font-family: 'Bebas Neue', sans-serif; font-size: 24px; letter-spacing: 1px;
-      margin-bottom: 16px; color: var(--accent);
-    }
+    .featured-highlight:hover { box-shadow: 0 4px 24px rgba(91,118,254,0.1); }
+    .featured-highlight h3 { font-family: 'Plus Jakarta Sans', sans-serif; font-size: 15px; font-weight: 700; color: var(--blue); letter-spacing: -0.3px; }
 
-    .empty-state { grid-column: 1 / -1; padding: 80px 40px; text-align: center; background: var(--bg-card); }
-    .empty-state h4 { font-family: 'Bebas Neue', sans-serif; font-size: 24px; letter-spacing: 1px; margin-bottom: 12px; }
-    .empty-state p { color: var(--text-dim); margin-bottom: 24px; }
+    .empty-state {
+      grid-column: 1 / -1; padding: 64px 40px; text-align: center;
+      background: white; border-radius: 16px; box-shadow: rgb(224,226,232) 0px 0px 0px 1px;
+    }
+    .empty-state h4 { font-family: 'Plus Jakarta Sans', sans-serif; font-size: 20px; font-weight: 700; letter-spacing: -0.5px; margin-bottom: 10px; }
+    .empty-state p { color: var(--slate); margin-bottom: 24px; font-size: 15px; }
 
     /* ─── SKILLS MATRIX ─── */
-    .skills-section { background: var(--bg-deep); }
-    .skills-layout { display: grid; grid-template-columns: 1fr 1fr; gap: 60px; align-items: start; }
+    .skills-section { background: var(--rose-light); }
+    .skills-layout { display: grid; grid-template-columns: 1fr 1fr; gap: 64px; align-items: start; }
     @media (max-width: 900px) { .skills-layout { grid-template-columns: 1fr; gap: 40px; } }
 
-    .skill-category { margin-bottom: 40px; }
+    .skill-category { margin-bottom: 36px; }
     .skill-category:last-child { margin-bottom: 0; }
     .skill-category-label {
-      font-size: 10px; font-weight: 600; letter-spacing: 2px; text-transform: uppercase;
-      color: var(--accent); margin-bottom: 20px; display: flex; align-items: center; gap: 10px;
+      font-family: 'Plus Jakarta Sans', sans-serif;
+      font-size: 11px; font-weight: 700; letter-spacing: 1px; text-transform: uppercase;
+      color: var(--blue); margin-bottom: 20px; display: flex; align-items: center; gap: 10px;
     }
-    .skill-category-label::after {
-      content: ''; flex: 1; height: 1px; background: var(--border);
-    }
+    .skill-category-label::after { content: ''; flex: 1; height: 1px; background: rgba(91,118,254,0.2); }
 
-    .skill-row { margin-bottom: 18px; }
+    .skill-row { margin-bottom: 16px; }
     .skill-meta { display: flex; justify-content: space-between; align-items: baseline; margin-bottom: 8px; }
-    .skill-name { font-size: 13px; font-weight: 500; color: var(--text-muted); }
-    .skill-level { font-size: 11px; font-weight: 600; letter-spacing: 1px; text-transform: uppercase; color: var(--text-dim); }
-    .skill-bar {
-      height: 3px; background: var(--border); position: relative; overflow: hidden;
-    }
+    .skill-name { font-size: 14px; font-weight: 500; color: var(--near-black); }
+    .skill-level { font-family: 'Plus Jakarta Sans', sans-serif; font-size: 11px; font-weight: 700; letter-spacing: 0.5px; color: var(--slate); }
+    .skill-bar { height: 4px; background: rgba(91,118,254,0.12); border-radius: 4px; position: relative; overflow: hidden; }
     .skill-fill {
       position: absolute; left: 0; top: 0; height: 100%;
-      background: linear-gradient(90deg, var(--accent) 0%, rgba(58,143,217,0.6) 100%);
-      width: 0%; transition: width 1.2s var(--ease-smooth);
-      transform-origin: left;
+      background: linear-gradient(90deg, var(--blue) 0%, rgba(91,118,254,0.65) 100%);
+      border-radius: 4px; width: 0%; transition: width 1.2s var(--ease-smooth);
     }
-    .skill-fill.animated { /* width set by JS */ }
 
     /* Specialty badges */
     .specialty-grid { display: grid; grid-template-columns: repeat(2, 1fr); gap: 12px; margin-top: 8px; }
     .specialty-badge {
-      padding: 14px 16px; background: var(--bg-card); border: 1px solid var(--border);
-      transition: border-color 0.3s ease, transform 0.3s var(--ease-spring), box-shadow 0.3s ease;
+      padding: 16px; background: white; border-radius: 16px;
+      box-shadow: rgb(224,226,232) 0px 0px 0px 1px;
+      transition: box-shadow 0.3s ease, transform 0.3s var(--ease-spring);
     }
-    .specialty-badge:hover {
-      border-color: rgba(58,143,217,0.4); transform: translateY(-3px);
-      box-shadow: 0 8px 24px rgba(0,0,0,0.3);
-    }
-    .specialty-badge-icon { font-size: 20px; margin-bottom: 8px; display: block; }
-    .specialty-badge-name { font-size: 12px; font-weight: 600; letter-spacing: 0.5px; color: var(--text); display: block; margin-bottom: 4px; }
-    .specialty-badge-desc { font-size: 11px; color: var(--text-dim); line-height: 1.4; }
+    .specialty-badge:hover { box-shadow: rgb(224,226,232) 0px 0px 0px 1px, 0 8px 24px rgba(91,118,254,0.1); transform: translateY(-3px); }
+    .specialty-badge-icon { font-size: 22px; margin-bottom: 10px; display: block; }
+    .specialty-badge-name { font-family: 'Plus Jakarta Sans', sans-serif; font-size: 13px; font-weight: 700; color: var(--near-black); display: block; margin-bottom: 6px; letter-spacing: -0.3px; }
+    .specialty-badge-desc { font-size: 12px; color: var(--slate); line-height: 1.5; }
 
     /* ─── END-TO-END PIPELINE ─── */
-    .pipeline-section { background: linear-gradient(180deg, var(--bg-deep) 0%, rgba(58,143,217,0.03) 50%, var(--bg-deep) 100%); }
-    .pipeline-intro { max-width: 680px; margin-bottom: 60px; }
-    .pipeline-intro p { font-size: 16px; color: var(--text-muted); line-height: 1.8; margin-top: 16px; }
+    .pipeline-section { background: var(--orange-light); }
+    .pipeline-intro { max-width: 680px; margin-bottom: 56px; }
+    .pipeline-intro p { font-size: 17px; color: var(--slate); line-height: 1.75; margin-top: 16px; }
 
     .pipeline-track { position: relative; }
     .pipeline-steps { display: grid; grid-template-columns: repeat(5, 1fr); gap: 0; position: relative; }
-    @media (max-width: 900px) { .pipeline-steps { grid-template-columns: 1fr; gap: 2px; background: var(--border); } }
+    @media (max-width: 900px) { .pipeline-steps { grid-template-columns: 1fr; gap: 12px; } }
 
-    /* Connecting line */
     .pipeline-line {
       position: absolute; top: 36px; left: 10%; right: 10%; height: 1px;
-      background: linear-gradient(90deg,
-        transparent 0%,
-        rgba(58,143,217,0.4) 20%,
-        rgba(58,143,217,0.6) 50%,
-        rgba(58,143,217,0.4) 80%,
-        transparent 100%);
-      z-index: 0;
-      transform: scaleX(0); transform-origin: left;
+      background: linear-gradient(90deg, transparent 0%, rgba(91,118,254,0.4) 20%, rgba(91,118,254,0.6) 50%, rgba(91,118,254,0.4) 80%, transparent 100%);
+      z-index: 0; transform: scaleX(0); transform-origin: left;
       transition: transform 1.4s var(--ease-smooth);
     }
     .pipeline-line.animated { transform: scaleX(1); }
@@ -652,176 +562,130 @@
 
     .pipeline-step {
       position: relative; z-index: 1; padding: 0 12px; text-align: center;
-      opacity: 0; transform: translateY(24px);
-      transition: opacity 0.6s var(--ease-smooth), transform 0.6s var(--ease-smooth);
+      opacity: 0; transform: translateY(20px);
+      transition: opacity 0.5s var(--ease-smooth), transform 0.5s var(--ease-smooth);
     }
     .pipeline-step.step-in { opacity: 1; transform: translateY(0); }
 
     .pipeline-node {
       width: 72px; height: 72px; margin: 0 auto 20px;
-      background: var(--bg-card); border: 1px solid var(--border);
+      background: white; border-radius: 20px;
+      box-shadow: rgb(224,226,232) 0px 0px 0px 1px;
       display: flex; align-items: center; justify-content: center;
       font-size: 26px; position: relative;
-      transition: border-color 0.3s ease, transform 0.3s var(--ease-spring), box-shadow 0.3s ease;
+      transition: box-shadow 0.3s ease, transform 0.3s var(--ease-spring);
     }
-    .pipeline-step:hover .pipeline-node {
-      border-color: rgba(58,143,217,0.5); transform: scale(1.1);
-      box-shadow: 0 0 30px rgba(58,143,217,0.2);
-    }
-    .pipeline-node::after {
-      content: ''; position: absolute; inset: -4px;
-      border: 1px solid rgba(58,143,217,0); border-radius: 0;
-      transition: border-color 0.3s ease;
-    }
-    .pipeline-step:hover .pipeline-node::after { border-color: rgba(58,143,217,0.2); }
+    .pipeline-step:hover .pipeline-node { box-shadow: rgb(224,226,232) 0px 0px 0px 1px, 0 8px 24px rgba(91,118,254,0.15); transform: scale(1.08); }
+    .pipeline-node::after { display: none; }
 
     .pipeline-step-num {
       position: absolute; top: -8px; right: -8px;
-      width: 20px; height: 20px; background: var(--accent);
-      font-family: 'Bebas Neue', sans-serif; font-size: 12px;
+      width: 22px; height: 22px; background: var(--blue); border-radius: 50%;
+      font-family: 'Plus Jakarta Sans', sans-serif; font-size: 11px; font-weight: 700;
       display: flex; align-items: center; justify-content: center; color: white;
     }
-    .pipeline-step-title {
-      font-family: 'Bebas Neue', sans-serif; font-size: 15px; letter-spacing: 1px;
-      color: var(--text); margin-bottom: 8px;
-    }
+    .pipeline-step-title { font-family: 'Plus Jakarta Sans', sans-serif; font-size: 13px; font-weight: 700; color: var(--near-black); margin-bottom: 8px; letter-spacing: -0.3px; }
     .pipeline-step-tools { display: flex; flex-wrap: wrap; gap: 4px; justify-content: center; margin-bottom: 10px; }
     .pipeline-tool {
-      font-size: 9px; font-weight: 600; letter-spacing: 0.5px; text-transform: uppercase;
-      padding: 3px 8px; background: rgba(58,143,217,0.1); border: 1px solid rgba(58,143,217,0.25);
-      color: var(--accent);
+      font-family: 'Plus Jakarta Sans', sans-serif; font-size: 10px; font-weight: 700;
+      padding: 3px 9px; background: rgba(91,118,254,0.1); border: 1px solid rgba(91,118,254,0.25);
+      border-radius: 20px; color: var(--blue);
     }
-    .pipeline-step-desc { font-size: 12px; color: var(--text-dim); line-height: 1.5; }
+    .pipeline-step-desc { font-size: 12px; color: var(--slate); line-height: 1.5; }
 
-    /* Arrow between steps */
-    .pipeline-arrow {
-      display: none;
-    }
     @media (max-width: 900px) {
-      .pipeline-step { padding: 24px; text-align: left; background: var(--bg-card); }
-      .pipeline-node { width: 48px; height: 48px; font-size: 20px; float: left; margin: 0 16px 0 0; }
-      .pipeline-step-title { margin-top: 4px; }
+      .pipeline-step { padding: 20px; text-align: left; background: white; border-radius: 16px; box-shadow: rgb(224,226,232) 0px 0px 0px 1px; display: flex; align-items: flex-start; gap: 16px; }
+      .pipeline-node { width: 52px; height: 52px; font-size: 22px; flex-shrink: 0; margin: 0; }
+      .pipeline-step-title { margin-top: 2px; }
     }
 
     /* Use case chips */
-    .use-case-strip {
-      display: flex; flex-wrap: wrap; gap: 10px; margin-top: 48px; justify-content: center;
-    }
+    .use-case-strip { display: flex; flex-wrap: wrap; gap: 10px; margin-top: 48px; justify-content: center; }
     .use-case-chip {
-      padding: 10px 20px; background: var(--bg-card); border: 1px solid var(--border);
-      font-size: 12px; color: var(--text-muted); letter-spacing: 0.5px;
-      transition: border-color 0.3s ease, color 0.3s ease, transform 0.2s var(--ease-spring);
+      padding: 10px 20px; background: white; border-radius: 50px;
+      box-shadow: rgb(224,226,232) 0px 0px 0px 1px;
+      font-family: 'Plus Jakarta Sans', sans-serif; font-size: 13px; font-weight: 500; color: var(--near-black);
+      transition: box-shadow 0.2s ease, transform 0.2s var(--ease-spring);
     }
-    .use-case-chip:hover { border-color: var(--accent); color: var(--text); transform: translateY(-2px); }
-    .use-case-chip span { color: var(--accent); margin-right: 6px; }
+    .use-case-chip:hover { box-shadow: rgb(224,226,232) 0px 0px 0px 1px, 0 4px 16px rgba(91,118,254,0.1); transform: translateY(-2px); }
+    .use-case-chip span { color: var(--blue); margin-right: 4px; }
 
     /* ─── FREELANCE CTA ─── */
-    .freelance-section {
-      background: linear-gradient(135deg, rgba(58,143,217,0.08) 0%, rgba(201,162,39,0.05) 100%);
-      border-top: 1px solid rgba(58,143,217,0.15);
-      border-bottom: 1px solid rgba(58,143,217,0.15);
-    }
+    .freelance-section { background: var(--blue); border: none; }
     .freelance-inner {
-      display: grid; grid-template-columns: 1fr auto; gap: 60px; align-items: center;
-      padding: 64px 0;
+      display: grid; grid-template-columns: 1fr auto; gap: 64px; align-items: center;
+      padding: 72px 0;
     }
-    @media (max-width: 768px) { .freelance-inner { grid-template-columns: 1fr; gap: 32px; } }
+    @media (max-width: 768px) { .freelance-inner { grid-template-columns: 1fr; gap: 36px; } }
 
     .freelance-tag {
       display: inline-flex; align-items: center; gap: 8px;
-      font-size: 10px; font-weight: 600; letter-spacing: 2px; text-transform: uppercase;
-      color: var(--gold); margin-bottom: 16px;
+      font-family: 'Plus Jakarta Sans', sans-serif;
+      font-size: 12px; font-weight: 700; letter-spacing: 1px; text-transform: uppercase;
+      color: rgba(255,255,255,0.8); margin-bottom: 16px;
     }
-    .freelance-tag::before {
-      content: ''; width: 6px; height: 6px; background: var(--gold); border-radius: 50%;
-      animation: pulse 2s infinite;
-    }
+    .freelance-tag::before { content: ''; width: 7px; height: 7px; background: var(--success); border-radius: 50%; animation: pulse 2s infinite; }
     .freelance-heading {
-      font-family: 'Bebas Neue', sans-serif; font-size: clamp(32px, 4vw, 52px);
-      letter-spacing: 2px; line-height: 1.05; margin-bottom: 20px;
+      font-family: 'Plus Jakarta Sans', sans-serif;
+      font-size: clamp(28px, 4vw, 48px); font-weight: 800;
+      letter-spacing: -1.5px; line-height: 1.1; margin-bottom: 20px; color: white;
     }
-    .freelance-heading span { color: var(--accent); }
-    .freelance-body {
-      font-size: 15px; color: var(--text-muted); max-width: 560px; line-height: 1.8;
-      margin-bottom: 28px;
-    }
+    .freelance-heading span { color: rgba(255,255,255,0.65); }
+    .freelance-body { font-size: 16px; color: rgba(255,255,255,0.8); max-width: 560px; line-height: 1.75; margin-bottom: 28px; }
     .freelance-services { display: flex; flex-wrap: wrap; gap: 8px; }
     .freelance-service {
-      padding: 7px 14px; background: rgba(255,255,255,0.04); border: 1px solid var(--border);
-      font-size: 11px; font-weight: 600; letter-spacing: 1px; text-transform: uppercase;
-      color: var(--text-muted);
+      padding: 7px 16px; background: rgba(255,255,255,0.12); border: 1px solid rgba(255,255,255,0.25);
+      border-radius: 20px; font-family: 'Plus Jakarta Sans', sans-serif;
+      font-size: 12px; font-weight: 600; color: white;
     }
     .freelance-cta { display: flex; flex-direction: column; align-items: center; gap: 16px; }
-    .cta-availability {
-      text-align: center; font-size: 11px; color: var(--text-dim);
-      letter-spacing: 1px; text-transform: uppercase;
-    }
-    .cta-dot {
-      display: inline-block; width: 7px; height: 7px; background: #4caf50;
-      border-radius: 50%; margin-right: 6px; animation: pulse 2s infinite;
-    }
+    .cta-availability { text-align: center; font-family: 'Plus Jakarta Sans', sans-serif; font-size: 12px; color: rgba(255,255,255,0.7); letter-spacing: 0.5px; }
+    .cta-dot { display: inline-block; width: 7px; height: 7px; background: var(--success); border-radius: 50%; margin-right: 6px; animation: pulse 2s infinite; }
 
     /* ─── IMPACT STATS STRIP ─── */
-    .impact-stats-section {
-      padding: 56px 0;
-      background: var(--bg-card);
-      border-top: 1px solid var(--border);
-      border-bottom: 1px solid var(--border);
-    }
-    .impact-stats-grid {
-      display: grid; grid-template-columns: repeat(4, 1fr); gap: 0;
-    }
+    .impact-stats-section { padding: 64px 0; background: var(--teal-light); border-top: none; border-bottom: none; }
+    .impact-stats-grid { display: grid; grid-template-columns: repeat(4, 1fr); gap: 0; }
     .impact-stat {
       display: flex; flex-direction: column; align-items: center; justify-content: center;
-      padding: 24px 20px; text-align: center;
-      border-right: 1px solid var(--border);
+      padding: 24px 20px; text-align: center; border-right: 1px solid rgba(24,117,116,0.2);
     }
     .impact-stat:last-child { border-right: none; }
     .impact-value {
-      font-family: 'Bebas Neue', sans-serif; font-size: clamp(42px, 5vw, 64px);
-      letter-spacing: 2px; color: var(--accent); line-height: 1;
+      font-family: 'Plus Jakarta Sans', sans-serif;
+      font-size: clamp(40px, 5vw, 64px); font-weight: 800; letter-spacing: -2px;
+      color: var(--teal-dark); line-height: 1;
     }
-    .impact-label {
-      font-size: 11px; font-weight: 600; letter-spacing: 1.5px; text-transform: uppercase;
-      color: var(--text-muted); margin-top: 8px;
-    }
+    .impact-label { font-family: 'Plus Jakarta Sans', sans-serif; font-size: 13px; font-weight: 600; color: var(--teal-dark); margin-top: 8px; opacity: 0.8; }
     @media (max-width: 768px) {
       .impact-stats-grid { grid-template-columns: repeat(2, 1fr); }
       .impact-stat:nth-child(2) { border-right: none; }
-      .impact-stat:nth-child(3) { border-right: 1px solid var(--border); border-top: 1px solid var(--border); }
-      .impact-stat:nth-child(4) { border-right: none; border-top: 1px solid var(--border); }
+      .impact-stat:nth-child(3) { border-right: 1px solid rgba(24,117,116,0.2); border-top: 1px solid rgba(24,117,116,0.2); }
+      .impact-stat:nth-child(4) { border-right: none; border-top: 1px solid rgba(24,117,116,0.2); }
     }
     @media (max-width: 480px) {
       .impact-stats-grid { grid-template-columns: 1fr; }
-      .impact-stat { border-right: none !important; border-top: 1px solid var(--border); }
+      .impact-stat { border-right: none !important; border-top: 1px solid rgba(24,117,116,0.2); }
       .impact-stat:first-child { border-top: none; }
     }
 
     /* ─── PAGE LOAD OVERLAY ─── */
     #page-loader {
-      position: fixed; inset: 0; background: var(--bg-deep); z-index: 99999;
+      position: fixed; inset: 0; background: var(--bg); z-index: 99999;
       display: flex; align-items: center; justify-content: center;
-      transition: opacity 0.6s var(--ease-smooth), transform 0.6s var(--ease-smooth);
+      transition: opacity 0.6s var(--ease-smooth);
     }
     #page-loader.done { opacity: 0; pointer-events: none; }
-    .loader-inner {
-      text-align: center;
-      animation: loaderPulse 1s var(--ease-apple) infinite alternate;
-    }
-    @keyframes loaderPulse {
-      from { opacity: 0.6; transform: scale(0.98); }
-      to   { opacity: 1;   transform: scale(1); }
-    }
+    .loader-inner { text-align: center; }
     .loader-logo {
-      font-family: 'Bebas Neue', sans-serif; font-size: 48px; letter-spacing: 4px;
-      color: var(--accent);
+      font-family: 'Plus Jakarta Sans', sans-serif; font-size: 48px; font-weight: 800;
+      color: var(--blue); letter-spacing: -3px;
     }
     .loader-bar {
-      width: 120px; height: 2px; background: var(--border);
-      margin: 16px auto 0; overflow: hidden;
+      width: 120px; height: 3px; background: var(--ring);
+      margin: 16px auto 0; overflow: hidden; border-radius: 4px;
     }
     .loader-progress {
-      height: 100%; width: 0%; background: var(--accent);
+      height: 100%; width: 0%; background: var(--blue); border-radius: 4px;
       animation: loadProgress 0.8s var(--ease-smooth) forwards;
     }
     @keyframes loadProgress {
@@ -858,11 +722,6 @@
   </header>
 
   <section class="hero" id="top">
-    <!-- Animated background orbs -->
-    <div class="hero-orb hero-orb-1"></div>
-    <div class="hero-orb hero-orb-2"></div>
-    <div class="hero-orb hero-orb-3"></div>
-
     <div class="container">
       <div class="hero-content">
         <div class="hero-text">
@@ -1522,7 +1381,7 @@ ranked_data <span class="keyword">AS</span> (
           </div>
         </div>
         <div class="freelance-cta">
-          <a href="mailto:daveneejames@gmail.com?subject=Job%20Opportunity" class="btn btn-primary" style="white-space:nowrap; font-size:13px; padding:18px 36px;">
+          <a href="mailto:daveneejames@gmail.com?subject=Job%20Opportunity" class="btn btn-white" style="white-space:nowrap;">
             Get in Touch
           </a>
           <div class="cta-availability">


### PR DESCRIPTION
Visual redesign of the portfolio to match the Miro design system.

## Summary
- White canvas with near-black text, blue `#5b76fe` for interactive elements
- Plus Jakarta Sans (display) + Noto Sans (body), replacing Bebas Neue/Barlow
- Ring-shadow card borders + 16-24px border-radius replacing flat dark tiles
- Pastel section backgrounds: teal (impact), rose (skills), orange (pipeline), solid blue (CTA)
- Modal, header, loader, and buttons all updated to match

https://claude.ai/code/session_01N7FPY66Q2orTxWFJZGo79j

---
_Generated by [Claude Code](https://claude.ai/code/session_01N7FPY66Q2orTxWFJZGo79j)_