### PR TITLE
Tune scrolling perf and add reduced-motion support

### DIFF
--- a/index.html
+++ b/index.html
@@ -61,8 +61,9 @@
       transition: background 0.5s var(--ease-apple), box-shadow 0.5s var(--ease-apple);
     }
     header.scrolled {
-      background: rgba(255,255,255,0.96);
-      backdrop-filter: blur(20px) saturate(180%);
+      background: rgba(255,255,255,0.92);
+      backdrop-filter: blur(10px);
+      -webkit-backdrop-filter: blur(10px);
       box-shadow: rgb(224,226,232) 0px 1px 0px 0px;
     }
 
@@ -300,6 +301,7 @@
       transition: box-shadow 0.3s ease, transform 0.3s var(--ease-spring);
       cursor: pointer;
       opacity: 0; transform: translateY(24px) scale(0.98);
+      contain: layout paint;
     }
     .dashboard-card.card-visible { opacity: 1; transform: translateY(0) scale(1); }
     .dashboard-card:hover {
@@ -463,7 +465,7 @@
       display: none; align-items: center; justify-content: center; padding: 40px; z-index: 2000;
       transition: background 0.35s ease, backdrop-filter 0.35s ease;
     }
-    .modal-overlay.open { background: rgba(28,28,30,0.65); backdrop-filter: blur(12px); }
+    .modal-overlay.open { background: rgba(28,28,30,0.7); backdrop-filter: blur(8px); -webkit-backdrop-filter: blur(8px); }
     .modal {
       width: 100%; max-width: 860px; background: white; border-radius: 24px;
       box-shadow: 0 32px 80px rgba(0,0,0,0.18);
@@ -771,6 +773,22 @@
     @keyframes loadProgress {
       from { width: 0%; }
       to   { width: 100%; }
+    }
+
+    /* ─── REDUCED MOTION ─── */
+    @media (prefers-reduced-motion: reduce) {
+      *, *::before, *::after {
+        animation-duration: 0.001ms !important;
+        animation-iteration-count: 1 !important;
+        transition-duration: 0.001ms !important;
+        scroll-behavior: auto !important;
+      }
+      .reveal, .reveal-left, .reveal-right, .stagger-children > *,
+      .hero-badge, .hero h1, .hero-desc, .hero-actions,
+      .profile-card, .logo, nav a, .dashboard-card, .pipeline-step {
+        opacity: 1 !important; transform: none !important;
+      }
+      .hero::before, .hero::after { display: none; }
     }
   </style>
 </head>
@@ -1642,8 +1660,19 @@ ranked_data <span class="keyword">AS</span> (
 
     // ── SCROLL HEADER ─────────────────────────────────────
     const header = document.getElementById('site-header');
+    let scrolledState = false;
+    let scrollTicking = false;
     window.addEventListener('scroll', () => {
-      header.classList.toggle('scrolled', window.scrollY > 60);
+      if (scrollTicking) return;
+      scrollTicking = true;
+      requestAnimationFrame(() => {
+        const shouldScroll = window.scrollY > 60;
+        if (shouldScroll !== scrolledState) {
+          scrolledState = shouldScroll;
+          header.classList.toggle('scrolled', shouldScroll);
+        }
+        scrollTicking = false;
+      });
     }, { passive: true });
 
     // ── INTERSECTION OBSERVER ─────────────────────────────
@@ -1651,10 +1680,6 @@ ranked_data <span class="keyword">AS</span> (
       entries.forEach(entry => {
         if (entry.isIntersecting) {
           entry.target.classList.add('visible');
-          // Trigger counter animation if stat-box is visible
-          entry.target.querySelectorAll('.stat-value[data-target], .impact-value[data-target]').forEach(el => {
-            animateCounter(el);
-          });
           revealObserver.unobserve(entry.target);
         }
       });
@@ -1664,7 +1689,7 @@ ranked_data <span class="keyword">AS</span> (
       revealObserver.observe(el);
     });
 
-    // Also observe stat boxes individually
+    // Counter animation observer (dedicated, fires once per element)
     const statObserver = new IntersectionObserver((entries) => {
       entries.forEach(entry => {
         if (entry.isIntersecting) {


### PR DESCRIPTION
Targeted performance pass for smoother scrolling.

## Summary
- Drops the expensive `saturate(180%)` from the scrolled-header and modal backdrop filters (saturate is one of the most expensive backdrop filter functions) and lowers blur radius
- rAF-throttles the scroll handler and only toggles the `scrolled` class when the state actually changes — avoids repeatedly setting the same class on fast scroll
- `contain: layout paint` on dashboard cards so each card's repaint is isolated from siblings
- Removes the duplicate counter-trigger inside `revealObserver` (dedicated `statObserver` already handles `.stat-value` / `.impact-value`)
- Adds a `prefers-reduced-motion` block that disables transitions/animations and hides the hero radial gradients for users who opt out

## Test plan
- [ ] Scroll up/down on the live preview — header transition should still appear at ~60px
- [ ] Stat counters still animate when scrolled into view (impact-stats, SQL section)
- [ ] No visual regression on dashboard card hover
- [ ] System "reduce motion" setting renders everything immediately visible

https://claude.ai/code/session_01N7FPY66Q2orTxWFJZGo79j

---
_Generated by [Claude Code](https://claude.ai/code/session_01N7FPY66Q2orTxWFJZGo79j)_