### PR TITLE
Redesign portfolio to Notion design system

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,26 +7,22 @@
   <meta name="description" content="Power BI dashboards, demos, and analytics work by Davenee James." />
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@400;500;600;700;800&family=Noto+Sans:wght@400;500;600&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
 
   <style>
     :root {
-      --near-black: #1c1c1e;
+      --near-black: #1a1915;
       --white: #ffffff;
-      --blue: #5b76fe;
-      --blue-pressed: #2a41b6;
-      --slate: #555a6a;
-      --placeholder: #a5a8b5;
-      --border: #c7cad5;
-      --ring: rgb(224,226,232);
-      --success: #00b473;
-      --teal-light: #c3faf5;
-      --teal-dark: #187574;
-      --coral-light: #ffc6c6;
-      --rose-light: #ffd8f4;
-      --orange-light: #ffe6cd;
+      --blue: #0075de;
+      --blue-pressed: #0062be;
+      --warm-gray: #615d59;
+      --warm-gray-light: #a39e98;
+      --warm-black: #31302e;
+      --border: rgba(0,0,0,0.1);
+      --border-subtle: rgba(0,0,0,0.05);
+      --success: #0f7b55;
       --bg: #ffffff;
-      --bg-subtle: #f8f9fb;
+      --bg-subtle: #f6f5f4;
       --code-keyword: #ff7b72;
       --code-function: #d2a8ff;
       --code-string: #a5d6ff;
@@ -35,13 +31,16 @@
       --ease-apple: cubic-bezier(0.25, 0.46, 0.45, 0.94);
       --ease-spring: cubic-bezier(0.34, 1.56, 0.64, 1);
       --ease-smooth: cubic-bezier(0.16, 1, 0.3, 1);
+      --shadow-card: 0 0 0 1px rgba(0,0,0,0.08), 0 2px 4px rgba(0,0,0,0.04), 0 8px 24px rgba(0,0,0,0.06);
+      --shadow-card-hover: 0 0 0 1px rgba(0,0,0,0.08), 0 4px 8px rgba(0,0,0,0.06), 0 20px 48px rgba(0,0,0,0.10);
+      --shadow-elevated: 0 0 0 1px rgba(0,0,0,0.08), 0 8px 16px rgba(0,0,0,0.06), 0 32px 80px rgba(0,0,0,0.14);
     }
 
     * { box-sizing: border-box; margin: 0; padding: 0; }
     html { scroll-behavior: smooth; }
 
     body {
-      font-family: 'Noto Sans', sans-serif;
+      font-family: 'Inter', sans-serif;
       background: var(--bg);
       color: var(--near-black);
       line-height: 1.5;
@@ -61,10 +60,10 @@
       transition: background 0.5s var(--ease-apple), box-shadow 0.5s var(--ease-apple);
     }
     header.scrolled {
-      background: rgba(255,255,255,0.92);
-      backdrop-filter: blur(10px);
-      -webkit-backdrop-filter: blur(10px);
-      box-shadow: rgb(224,226,232) 0px 1px 0px 0px;
+      background: rgba(255,255,255,0.94);
+      backdrop-filter: blur(12px);
+      -webkit-backdrop-filter: blur(12px);
+      box-shadow: 0 1px 0 rgba(0,0,0,0.08);
     }
 
     .header-inner { display: flex; align-items: center; justify-content: space-between; height: 68px; }
@@ -75,29 +74,29 @@
     }
     .logo.visible { opacity: 1; transform: translateY(0); }
     .logo-icon {
-      width: 36px; height: 36px; border-radius: 10px;
+      width: 36px; height: 36px; border-radius: 8px;
       background: var(--blue);
       display: flex; align-items: center; justify-content: center;
-      font-family: 'Plus Jakarta Sans', sans-serif;
-      font-size: 14px; font-weight: 800; color: white; letter-spacing: -0.5px;
+      font-family: 'Inter', sans-serif;
+      font-size: 13px; font-weight: 700; color: white; letter-spacing: -0.3px;
       transition: transform 0.3s var(--ease-spring), box-shadow 0.3s ease;
     }
     .logo:hover .logo-icon {
       transform: scale(1.08) rotate(-4deg);
-      box-shadow: 0 4px 14px rgba(91,118,254,0.4);
+      box-shadow: 0 4px 14px rgba(0,117,222,0.3);
     }
-    .logo-text { font-family: 'Plus Jakarta Sans', sans-serif; font-size: 15px; font-weight: 700; letter-spacing: -0.3px; color: var(--near-black); }
+    .logo-text { font-family: 'Inter', sans-serif; font-size: 14px; font-weight: 600; letter-spacing: -0.2px; color: var(--near-black); }
 
     nav { display: flex; align-items: center; gap: 4px; }
     nav a {
-      font-family: 'Plus Jakarta Sans', sans-serif;
-      font-size: 14px; font-weight: 600; padding: 7px 14px; border-radius: 8px;
-      color: var(--slate); transition: color 0.2s ease, background 0.2s ease;
+      font-family: 'Inter', sans-serif;
+      font-size: 14px; font-weight: 500; padding: 7px 14px; border-radius: 6px;
+      color: var(--warm-gray); transition: color 0.2s ease, background 0.2s ease;
       opacity: 0; transform: translateY(-12px);
     }
     nav a.visible { opacity: 1; transform: translateY(0); transition: opacity 0.5s var(--ease-smooth), transform 0.5s var(--ease-smooth), color 0.2s ease, background 0.2s ease; }
     nav a:hover { color: var(--near-black); background: var(--bg-subtle); }
-    nav a[href$=".pdf"] { border: 1px solid var(--border); color: var(--near-black); }
+    nav a[href$=".pdf"] { border: 1px solid var(--border); color: var(--near-black); border-radius: 4px; }
     nav a[href$=".pdf"]:hover { background: var(--blue); border-color: var(--blue); color: white; }
 
     @media (max-width: 900px) { nav { gap: 2px; } nav a { font-size: 13px; padding: 6px 10px; } }
@@ -108,18 +107,6 @@
       min-height: 100vh; display: flex; align-items: center; position: relative; overflow: hidden;
       background: var(--bg);
     }
-    .hero::before {
-      content: ''; position: absolute; top: -10%; right: -8%; width: 560px; height: 560px;
-      border-radius: 50%;
-      background: radial-gradient(circle, var(--teal-light) 0%, transparent 70%);
-      opacity: 0.6; pointer-events: none;
-    }
-    .hero::after {
-      content: ''; position: absolute; bottom: -15%; left: -5%; width: 400px; height: 400px;
-      border-radius: 50%;
-      background: radial-gradient(circle, var(--rose-light) 0%, transparent 70%);
-      opacity: 0.5; pointer-events: none;
-    }
 
     .hero-content {
       display: grid; grid-template-columns: 1fr 400px; gap: 64px; align-items: center;
@@ -129,24 +116,24 @@
 
     .hero-badge {
       display: inline-flex; align-items: center; gap: 8px; padding: 6px 14px;
-      background: rgba(0,180,115,0.1); border: 1px solid rgba(0,180,115,0.3);
-      border-radius: 50px;
-      font-family: 'Plus Jakarta Sans', sans-serif;
-      font-size: 13px; font-weight: 600; color: var(--teal-dark); margin-bottom: 20px;
+      background: rgba(15,123,85,0.08); border: 1px solid rgba(15,123,85,0.2);
+      border-radius: 9999px;
+      font-family: 'Inter', sans-serif;
+      font-size: 13px; font-weight: 500; color: var(--success); margin-bottom: 20px;
       opacity: 0; transform: translateY(16px);
       transition: opacity 0.6s var(--ease-smooth), transform 0.6s var(--ease-smooth);
     }
     .hero-badge.visible { opacity: 1; transform: translateY(0); }
     .hero-badge::before {
-      content: ''; width: 7px; height: 7px; background: var(--success); border-radius: 50%;
+      content: ''; width: 6px; height: 6px; background: var(--success); border-radius: 50%;
       animation: pulse 2s infinite;
     }
     @keyframes pulse { 0%, 100% { opacity: 1; } 50% { opacity: 0.4; } }
 
     .hero h1 {
-      font-family: 'Plus Jakarta Sans', sans-serif;
-      font-size: clamp(38px, 5.5vw, 64px); font-weight: 800;
-      letter-spacing: -2px; line-height: 1.08; margin-bottom: 24px; color: var(--near-black);
+      font-family: 'Inter', sans-serif;
+      font-size: clamp(38px, 5.5vw, 64px); font-weight: 700;
+      letter-spacing: -2.125px; line-height: 1.08; margin-bottom: 24px; color: var(--near-black);
       opacity: 0; transform: translateY(24px);
       transition: opacity 0.7s var(--ease-smooth) 0.1s, transform 0.7s var(--ease-smooth) 0.1s;
     }
@@ -154,7 +141,7 @@
     .hero h1 span { color: var(--blue); }
 
     .hero-desc {
-      font-size: 17px; color: var(--slate); max-width: 500px;
+      font-size: 17px; color: var(--warm-gray); max-width: 500px;
       line-height: 1.7; margin-bottom: 36px;
       opacity: 0; transform: translateY(24px);
       transition: opacity 0.7s var(--ease-smooth) 0.2s, transform 0.7s var(--ease-smooth) 0.2s;
@@ -169,9 +156,9 @@
     .hero-actions.visible { opacity: 1; transform: translateY(0); }
 
     .btn {
-      display: inline-flex; align-items: center; gap: 8px; padding: 12px 24px;
-      font-family: 'Plus Jakarta Sans', sans-serif;
-      font-size: 15px; font-weight: 700; border-radius: 8px;
+      display: inline-flex; align-items: center; gap: 8px; padding: 10px 18px;
+      font-family: 'Inter', sans-serif;
+      font-size: 14px; font-weight: 500; border-radius: 4px;
       border: 1px solid var(--border); background: transparent; color: var(--near-black);
       cursor: pointer;
       transition: background 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease, transform 0.2s var(--ease-spring);
@@ -179,43 +166,43 @@
     .btn:hover { background: var(--bg-subtle); transform: translateY(-1px); }
     .btn:active { transform: translateY(0) scale(0.98); }
     .btn-primary { background: var(--blue); border-color: var(--blue); color: white; }
-    .btn-primary:hover { background: var(--blue-pressed); border-color: var(--blue-pressed); box-shadow: 0 4px 16px rgba(91,118,254,0.35); }
-    .btn-white { background: white; border-color: white; color: var(--blue); }
-    .btn-white:hover { background: rgba(255,255,255,0.9); box-shadow: 0 4px 16px rgba(0,0,0,0.15); }
+    .btn-primary:hover { background: var(--blue-pressed); border-color: var(--blue-pressed); box-shadow: 0 4px 16px rgba(0,117,222,0.22); }
+    .btn-white { background: white; border-color: rgba(0,0,0,0.15); color: var(--blue); }
+    .btn-white:hover { background: rgba(255,255,255,0.95); box-shadow: 0 4px 16px rgba(0,0,0,0.1); }
 
     /* ─── PROFILE CARD ─── */
     .profile-card {
-      background: white; border-radius: 24px;
-      box-shadow: rgb(224,226,232) 0px 0px 0px 1px, 0 8px 40px rgba(0,0,0,0.06);
+      background: white; border-radius: 16px;
+      box-shadow: var(--shadow-card);
       padding: 32px;
       opacity: 0; transform: translateX(40px) scale(0.97);
       transition: opacity 0.8s var(--ease-smooth) 0.2s, transform 0.8s var(--ease-smooth) 0.2s, box-shadow 0.3s ease;
     }
     .profile-card.visible { opacity: 1; transform: translateX(0) scale(1); }
-    .profile-card:hover { box-shadow: rgb(224,226,232) 0px 0px 0px 1px, 0 20px 60px rgba(91,118,254,0.1); }
+    .profile-card:hover { box-shadow: var(--shadow-card-hover); }
     .profile-header {
       display: flex; gap: 20px; align-items: center; margin-bottom: 24px;
-      padding-bottom: 24px; border-bottom: 1px solid var(--ring);
+      padding-bottom: 24px; border-bottom: 1px solid var(--border);
     }
     .profile-avatar {
       width: 80px; height: 80px; object-fit: cover;
-      border-radius: 50%; box-shadow: rgb(224,226,232) 0px 0px 0px 3px;
+      border-radius: 50%; box-shadow: 0 0 0 3px rgba(0,0,0,0.06);
       transition: transform 0.3s var(--ease-spring);
     }
     .profile-card:hover .profile-avatar { transform: scale(1.04); }
-    .profile-info h3 { font-family: 'Plus Jakarta Sans', sans-serif; font-size: 17px; font-weight: 700; letter-spacing: -0.5px; margin-bottom: 4px; }
-    .profile-info p { font-size: 13px; color: var(--slate); line-height: 1.5; }
+    .profile-info h3 { font-family: 'Inter', sans-serif; font-size: 16px; font-weight: 600; letter-spacing: -0.3px; margin-bottom: 4px; }
+    .profile-info p { font-size: 13px; color: var(--warm-gray); line-height: 1.5; }
     .profile-meta { display: flex; flex-direction: column; }
     .meta-item {
       display: flex; justify-content: space-between; align-items: flex-start; gap: 12px;
-      padding: 14px 0; border-bottom: 1px solid var(--ring);
+      padding: 14px 0; border-bottom: 1px solid var(--border);
     }
     .meta-item:last-child { border-bottom: none; padding-bottom: 0; }
-    .meta-label { font-family: 'Plus Jakarta Sans', sans-serif; font-size: 11px; font-weight: 700; letter-spacing: 0.5px; text-transform: uppercase; color: var(--placeholder); white-space: nowrap; }
-    .meta-value { font-size: 13px; color: var(--slate); text-align: right; line-height: 1.4; }
+    .meta-label { font-family: 'Inter', sans-serif; font-size: 11px; font-weight: 600; letter-spacing: 0.3px; text-transform: uppercase; color: var(--warm-gray-light); white-space: nowrap; }
+    .meta-value { font-size: 13px; color: var(--warm-gray); text-align: right; line-height: 1.4; }
 
     /* ─── SECTIONS ─── */
-    .section { padding: 80px 0; border-top: 1px solid var(--ring); }
+    .section { padding: 80px 0; border-top: 1px solid var(--border); }
     .section-header { margin-bottom: 48px; }
 
     .reveal {
@@ -248,16 +235,16 @@
     .stagger-children.visible > *:nth-child(8) { opacity:1; transform:translateY(0); transition-delay:0.49s; }
 
     .section-title {
-      font-family: 'Plus Jakarta Sans', sans-serif;
-      font-size: 12px; font-weight: 700; letter-spacing: 1px; text-transform: uppercase;
+      font-family: 'Inter', sans-serif;
+      font-size: 12px; font-weight: 600; letter-spacing: 0.5px; text-transform: uppercase;
       color: var(--blue); margin-bottom: 12px;
     }
     .section-heading {
-      font-family: 'Plus Jakarta Sans', sans-serif;
-      font-size: clamp(28px, 4vw, 48px); font-weight: 800; letter-spacing: -1.5px;
+      font-family: 'Inter', sans-serif;
+      font-size: clamp(28px, 4vw, 48px); font-weight: 700; letter-spacing: -1.5px;
       color: var(--near-black); line-height: 1.1;
     }
-    .section-desc { font-size: 17px; color: var(--slate); max-width: 600px; margin-top: 16px; line-height: 1.7; }
+    .section-desc { font-size: 17px; color: var(--warm-gray); max-width: 600px; margin-top: 16px; line-height: 1.7; }
 
     /* ─── SEARCH / FILTERS ─── */
     .controls {
@@ -266,19 +253,19 @@
     }
     .search-box {
       display: flex; align-items: center; gap: 10px; padding: 10px 16px;
-      background: white; border: 1px solid var(--border); border-radius: 8px; min-width: 280px;
+      background: white; border: 1px solid var(--border); border-radius: 6px; min-width: 280px;
       transition: border-color 0.2s ease, box-shadow 0.2s ease;
     }
-    .search-box:focus-within { border-color: var(--blue); box-shadow: 0 0 0 3px rgba(91,118,254,0.12); }
-    .search-box svg { width: 16px; height: 16px; color: var(--placeholder); flex-shrink: 0; }
-    .search-box input { flex: 1; background: transparent; border: none; outline: none; color: var(--near-black); font-family: 'Noto Sans', sans-serif; font-size: 14px; }
-    .search-box input::placeholder { color: var(--placeholder); }
+    .search-box:focus-within { border-color: var(--blue); box-shadow: 0 0 0 3px rgba(0,117,222,0.1); }
+    .search-box svg { width: 16px; height: 16px; color: var(--warm-gray-light); flex-shrink: 0; }
+    .search-box input { flex: 1; background: transparent; border: none; outline: none; color: var(--near-black); font-family: 'Inter', sans-serif; font-size: 14px; }
+    .search-box input::placeholder { color: var(--warm-gray-light); }
 
     .filter-tabs { display: flex; gap: 4px; }
     .filter-tabs button {
-      padding: 8px 18px; background: transparent; border: 1px solid var(--border); border-radius: 8px;
-      color: var(--slate); font-family: 'Plus Jakarta Sans', sans-serif;
-      font-size: 13px; font-weight: 600; cursor: pointer; transition: all 0.2s ease;
+      padding: 8px 18px; background: transparent; border: 1px solid var(--border); border-radius: 4px;
+      color: var(--warm-gray); font-family: 'Inter', sans-serif;
+      font-size: 13px; font-weight: 500; cursor: pointer; transition: all 0.2s ease;
     }
     .filter-tabs button:hover { background: var(--bg-subtle); color: var(--near-black); }
     .filter-tabs button.active { background: var(--blue); border-color: var(--blue); color: white; }
@@ -295,8 +282,8 @@
     @media (max-width: 600px)  { .dashboard-grid { grid-template-columns: 1fr; } }
 
     .dashboard-card {
-      background: white; border-radius: 16px;
-      box-shadow: rgb(224,226,232) 0px 0px 0px 1px;
+      background: white; border-radius: 12px;
+      box-shadow: var(--shadow-card);
       display: flex; flex-direction: column; overflow: hidden;
       transition: box-shadow 0.3s ease, transform 0.3s var(--ease-spring);
       cursor: pointer;
@@ -305,7 +292,7 @@
     }
     .dashboard-card.card-visible { opacity: 1; transform: translateY(0) scale(1); }
     .dashboard-card:hover {
-      box-shadow: rgb(224,226,232) 0px 0px 0px 1px, 0 12px 40px rgba(91,118,254,0.12);
+      box-shadow: var(--shadow-card-hover);
       transform: translateY(-4px);
     }
     .card-image { position: relative; aspect-ratio: 16/10; overflow: hidden; background: var(--bg-subtle); }
@@ -321,63 +308,63 @@
     }
     .card-tags { position: absolute; bottom: 10px; left: 10px; display: flex; gap: 6px; z-index: 1; }
     .tag {
-      padding: 4px 10px; background: rgba(255,255,255,0.9); border-radius: 20px;
-      font-family: 'Plus Jakarta Sans', sans-serif;
-      font-size: 11px; font-weight: 700; color: var(--near-black);
+      padding: 4px 10px; background: rgba(255,255,255,0.9); border-radius: 9999px;
+      font-family: 'Inter', sans-serif;
+      font-size: 11px; font-weight: 600; color: var(--near-black);
       backdrop-filter: blur(4px);
     }
     .tag-live { background: var(--blue); color: white; }
     .card-body { padding: 16px; flex: 1; display: flex; flex-direction: column; }
-    .card-body h4 { font-family: 'Plus Jakarta Sans', sans-serif; font-size: 14px; font-weight: 700; letter-spacing: -0.3px; margin-bottom: 6px; color: var(--near-black); }
-    .card-body p { font-size: 12px; color: var(--slate); line-height: 1.55; flex: 1; margin-bottom: 14px; }
+    .card-body h4 { font-family: 'Inter', sans-serif; font-size: 14px; font-weight: 600; letter-spacing: -0.2px; margin-bottom: 6px; color: var(--near-black); }
+    .card-body p { font-size: 12px; color: var(--warm-gray); line-height: 1.55; flex: 1; margin-bottom: 14px; }
     .card-actions { display: flex; gap: 8px; }
     .card-btn {
-      flex: 1; padding: 8px 12px; background: transparent; border: 1px solid var(--border); border-radius: 8px;
-      color: var(--near-black); font-family: 'Plus Jakarta Sans', sans-serif;
-      font-size: 12px; font-weight: 600; cursor: pointer; transition: all 0.2s ease; text-align: center;
+      flex: 1; padding: 8px 12px; background: transparent; border: 1px solid var(--border); border-radius: 4px;
+      color: var(--near-black); font-family: 'Inter', sans-serif;
+      font-size: 12px; font-weight: 500; cursor: pointer; transition: all 0.2s ease; text-align: center;
     }
     .card-btn:hover { background: var(--bg-subtle); transform: translateY(-1px); }
     .card-btn-primary { background: var(--blue); border-color: var(--blue); color: white; }
     .card-btn-primary:hover { background: var(--blue-pressed); border-color: var(--blue-pressed); }
 
     /* ─── SQL SECTION ─── */
-    .sql-showcase { background: #fdf6f0; }
+    .sql-showcase { background: var(--bg-subtle); }
     .showcase-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 48px; align-items: start; }
     @media (max-width: 1024px) { .showcase-grid { grid-template-columns: 1fr; } }
-    .showcase-content h3 { font-family: 'Plus Jakarta Sans', sans-serif; font-size: 22px; font-weight: 800; letter-spacing: -0.5px; margin-bottom: 16px; color: var(--near-black); }
-    .showcase-content p { font-size: 15px; color: var(--slate); line-height: 1.75; margin-bottom: 16px; }
+    .showcase-content h3 { font-family: 'Inter', sans-serif; font-size: 22px; font-weight: 700; letter-spacing: -0.5px; margin-bottom: 16px; color: var(--near-black); }
+    .showcase-content p { font-size: 15px; color: var(--warm-gray); line-height: 1.75; margin-bottom: 16px; }
 
     .showcase-stats { display: grid; grid-template-columns: repeat(3, 1fr); gap: 12px; margin: 28px 0; }
     .stat-box {
-      background: white; border-radius: 16px;
-      box-shadow: rgb(224,226,232) 0px 0px 0px 1px;
+      background: white; border-radius: 12px;
+      box-shadow: var(--shadow-card);
       padding: 20px; text-align: center;
       transition: box-shadow 0.3s ease, transform 0.3s var(--ease-spring);
     }
     .stat-box:hover {
-      box-shadow: rgb(224,226,232) 0px 0px 0px 1px, 0 8px 24px rgba(91,118,254,0.1);
+      box-shadow: var(--shadow-card-hover);
       transform: translateY(-3px);
     }
     .stat-value {
-      font-family: 'Plus Jakarta Sans', sans-serif;
-      font-size: 36px; font-weight: 800; color: var(--blue); letter-spacing: -1px; display: block;
+      font-family: 'Inter', sans-serif;
+      font-size: 36px; font-weight: 700; color: var(--blue); letter-spacing: -1px; display: block;
     }
-    .stat-label { font-family: 'Plus Jakarta Sans', sans-serif; font-size: 11px; font-weight: 600; color: var(--slate); margin-top: 4px; }
+    .stat-label { font-family: 'Inter', sans-serif; font-size: 11px; font-weight: 600; color: var(--warm-gray); margin-top: 4px; }
 
     .tech-tags { display: flex; flex-wrap: wrap; gap: 8px; margin-top: 24px; }
     .tech-tag {
-      padding: 6px 14px; background: rgba(91,118,254,0.08); border: 1px solid rgba(91,118,254,0.2);
-      border-radius: 20px; font-family: 'Plus Jakarta Sans', sans-serif;
-      font-size: 12px; font-weight: 600; color: var(--blue); transition: background 0.2s ease;
+      padding: 5px 12px; background: rgba(0,117,222,0.07); border: 1px solid rgba(0,117,222,0.15);
+      border-radius: 9999px; font-family: 'Inter', sans-serif;
+      font-size: 12px; font-weight: 500; color: var(--blue); transition: background 0.2s ease;
     }
-    .tech-tag:hover { background: rgba(91,118,254,0.16); }
+    .tech-tag:hover { background: rgba(0,117,222,0.14); }
 
     /* SQL Toggle */
     .sql-toggle { display: flex; gap: 4px; margin-bottom: 32px; width: fit-content; }
     .sql-toggle button {
-      padding: 10px 24px; background: white; border: 1px solid var(--border); border-radius: 8px;
-      color: var(--slate); font-family: 'Plus Jakarta Sans', sans-serif;
-      font-size: 14px; font-weight: 600; cursor: pointer; transition: all 0.2s ease;
+      padding: 9px 20px; background: white; border: 1px solid var(--border); border-radius: 4px;
+      color: var(--warm-gray); font-family: 'Inter', sans-serif;
+      font-size: 14px; font-weight: 500; cursor: pointer; transition: all 0.2s ease;
     }
     .sql-toggle button:hover { color: var(--near-black); background: var(--bg-subtle); }
     .sql-toggle button.active { color: white; background: var(--blue); border-color: var(--blue); }
@@ -390,7 +377,7 @@
       to   { opacity: 1; transform: translateY(0); }
     }
 
-    .code-container { background: #1e1e2e; border-radius: 16px; overflow: hidden; box-shadow: 0 8px 40px rgba(0,0,0,0.15); }
+    .code-container { background: #1e1e2e; border-radius: 12px; overflow: hidden; box-shadow: var(--shadow-elevated); }
     .code-header {
       display: flex; justify-content: space-between; align-items: center;
       padding: 12px 20px; background: rgba(255,255,255,0.05); border-bottom: 1px solid rgba(255,255,255,0.08);
@@ -399,7 +386,7 @@
     .code-lang {
       font-size: 10px; font-weight: 600; letter-spacing: 1px; text-transform: uppercase;
       color: var(--blue); padding: 4px 10px;
-      background: rgba(91,118,254,0.15); border: 1px solid rgba(91,118,254,0.3); border-radius: 4px;
+      background: rgba(0,117,222,0.12); border: 1px solid rgba(0,117,222,0.25); border-radius: 4px;
     }
     .code-block { padding: 20px; overflow-x: auto; max-height: 520px; overflow-y: auto; }
     .code-block pre { font-family: 'JetBrains Mono', monospace; font-size: 11px; line-height: 1.65; color: #e6edf3; margin: 0; white-space: pre; }
@@ -415,46 +402,46 @@
     @media (max-width: 900px) { .process-grid { grid-template-columns: repeat(2, 1fr); } }
     @media (max-width: 500px) { .process-grid { grid-template-columns: 1fr; } }
     .process-step {
-      background: white; border-radius: 16px;
-      box-shadow: rgb(224,226,232) 0px 0px 0px 1px;
+      background: white; border-radius: 12px;
+      box-shadow: var(--shadow-card);
       padding: 28px 24px; position: relative;
       transition: box-shadow 0.3s ease, transform 0.3s var(--ease-spring);
     }
-    .process-step:hover { box-shadow: rgb(224,226,232) 0px 0px 0px 1px, 0 8px 24px rgba(91,118,254,0.1); transform: translateY(-4px); }
+    .process-step:hover { box-shadow: var(--shadow-card-hover); transform: translateY(-4px); }
     .step-number {
-      font-family: 'Plus Jakarta Sans', sans-serif; font-size: 52px; font-weight: 800;
-      color: rgba(91,118,254,0.1); position: absolute; top: 12px; right: 16px; line-height: 1;
+      font-family: 'Inter', sans-serif; font-size: 52px; font-weight: 700;
+      color: rgba(0,117,222,0.07); position: absolute; top: 12px; right: 16px; line-height: 1;
       transition: color 0.3s ease;
     }
-    .process-step:hover .step-number { color: rgba(91,118,254,0.2); }
-    .process-step h4 { font-family: 'Plus Jakarta Sans', sans-serif; font-size: 14px; font-weight: 700; margin-bottom: 10px; color: var(--blue); }
-    .process-step p { font-size: 13px; color: var(--slate); line-height: 1.6; }
+    .process-step:hover .step-number { color: rgba(0,117,222,0.13); }
+    .process-step h4 { font-family: 'Inter', sans-serif; font-size: 14px; font-weight: 600; margin-bottom: 10px; color: var(--blue); }
+    .process-step p { font-size: 13px; color: var(--warm-gray); line-height: 1.6; }
 
     /* ─── CONTACT ─── */
     .contact-grid { display: grid; grid-template-columns: repeat(3, 1fr); gap: 16px; }
     @media (max-width: 768px) { .contact-grid { grid-template-columns: 1fr; } }
     .contact-card {
-      background: white; border-radius: 20px;
-      box-shadow: rgb(224,226,232) 0px 0px 0px 1px;
+      background: white; border-radius: 12px;
+      box-shadow: var(--shadow-card);
       padding: 36px; text-align: center;
       transition: box-shadow 0.3s ease, transform 0.3s var(--ease-spring);
     }
-    .contact-card:hover { box-shadow: rgb(224,226,232) 0px 0px 0px 1px, 0 12px 40px rgba(91,118,254,0.1); transform: translateY(-6px); }
+    .contact-card:hover { box-shadow: var(--shadow-card-hover); transform: translateY(-6px); }
     .contact-icon { font-size: 30px; margin-bottom: 16px; display: block; transition: transform 0.3s var(--ease-spring); }
     .contact-card:hover .contact-icon { transform: scale(1.15) rotate(-5deg); }
-    .contact-card h4 { font-family: 'Plus Jakarta Sans', sans-serif; font-size: 17px; font-weight: 700; margin-bottom: 10px; color: var(--near-black); letter-spacing: -0.5px; }
-    .contact-card p { font-size: 14px; color: var(--slate); line-height: 1.6; margin-bottom: 24px; }
+    .contact-card h4 { font-family: 'Inter', sans-serif; font-size: 17px; font-weight: 700; margin-bottom: 10px; color: var(--near-black); letter-spacing: -0.4px; }
+    .contact-card p { font-size: 14px; color: var(--warm-gray); line-height: 1.6; margin-bottom: 24px; }
 
     /* ─── FOOTER ─── */
-    footer { padding: 36px 0; border-top: 1px solid var(--ring); background: white; }
+    footer { padding: 36px 0; border-top: 1px solid var(--border); background: white; }
     .footer-inner { display: flex; justify-content: space-between; align-items: center; flex-wrap: wrap; gap: 16px; }
-    .footer-copy { font-size: 13px; color: var(--slate); }
+    .footer-copy { font-size: 13px; color: var(--warm-gray); }
     .footer-links { display: flex; gap: 24px; }
-    .footer-links a { font-family: 'Plus Jakarta Sans', sans-serif; font-size: 13px; font-weight: 500; color: var(--slate); transition: color 0.2s ease; }
+    .footer-links a { font-family: 'Inter', sans-serif; font-size: 13px; font-weight: 500; color: var(--warm-gray); transition: color 0.2s ease; }
     .footer-links a:hover { color: var(--near-black); }
     .back-to-top {
       display: flex; align-items: center; gap: 6px;
-      font-family: 'Plus Jakarta Sans', sans-serif; font-size: 13px; font-weight: 600; color: var(--blue);
+      font-family: 'Inter', sans-serif; font-size: 13px; font-weight: 600; color: var(--blue);
       cursor: pointer; transition: transform 0.2s ease;
     }
     .back-to-top:hover { transform: translateY(-2px); }
@@ -467,8 +454,8 @@
     }
     .modal-overlay.open { background: rgba(28,28,30,0.7); backdrop-filter: blur(8px); -webkit-backdrop-filter: blur(8px); }
     .modal {
-      width: 100%; max-width: 860px; background: white; border-radius: 24px;
-      box-shadow: 0 32px 80px rgba(0,0,0,0.18);
+      width: 100%; max-width: 860px; background: white; border-radius: 16px;
+      box-shadow: var(--shadow-elevated);
       transform: scale(0.94) translateY(16px); opacity: 0;
       transition: transform 0.4s var(--ease-smooth), opacity 0.4s var(--ease-smooth);
       overflow: hidden;
@@ -476,78 +463,78 @@
     .modal-overlay.open .modal { transform: scale(1) translateY(0); opacity: 1; }
     .modal-header {
       display: flex; justify-content: space-between; align-items: center;
-      padding: 20px 24px; border-bottom: 1px solid var(--ring);
+      padding: 20px 24px; border-bottom: 1px solid var(--border);
     }
-    .modal-title { font-family: 'Plus Jakarta Sans', sans-serif; font-size: 17px; font-weight: 700; letter-spacing: -0.5px; color: var(--near-black); }
-    .modal-meta { font-size: 13px; color: var(--slate); margin-top: 3px; }
+    .modal-title { font-family: 'Inter', sans-serif; font-size: 17px; font-weight: 600; letter-spacing: -0.3px; color: var(--near-black); }
+    .modal-meta { font-size: 13px; color: var(--warm-gray); margin-top: 3px; }
     .modal-close {
       width: 36px; height: 36px; display: flex; align-items: center; justify-content: center;
       background: var(--bg-subtle); border: 1px solid var(--border); border-radius: 50%;
-      color: var(--slate); font-size: 16px; cursor: pointer; transition: all 0.2s ease;
+      color: var(--warm-gray); font-size: 16px; cursor: pointer; transition: all 0.2s ease;
     }
-    .modal-close:hover { background: var(--ring); color: var(--near-black); transform: rotate(90deg); }
+    .modal-close:hover { background: var(--border); color: var(--near-black); transform: rotate(90deg); }
     .modal-body { padding: 24px; }
-    .modal-image { width: 100%; margin-bottom: 20px; border-radius: 12px; overflow: hidden; box-shadow: rgb(224,226,232) 0px 0px 0px 1px; }
+    .modal-image { width: 100%; margin-bottom: 20px; border-radius: 10px; overflow: hidden; box-shadow: var(--shadow-card); }
     .modal-image img { width: 100%; display: block; transition: transform 0.4s var(--ease-smooth); }
     .modal-image:hover img { transform: scale(1.02); }
     .modal-actions { display: flex; gap: 12px; }
 
     /* ─── FEATURED ─── */
     .featured-highlight {
-      background: rgba(91,118,254,0.06); border: 1px solid rgba(91,118,254,0.2);
-      border-radius: 16px; padding: 20px 28px; margin-bottom: 32px; transition: box-shadow 0.3s ease;
+      background: var(--bg-subtle); border: 1px solid var(--border);
+      border-radius: 10px; padding: 18px 24px; margin-bottom: 32px; transition: box-shadow 0.3s ease;
     }
-    .featured-highlight:hover { box-shadow: 0 4px 24px rgba(91,118,254,0.1); }
-    .featured-highlight h3 { font-family: 'Plus Jakarta Sans', sans-serif; font-size: 15px; font-weight: 700; color: var(--blue); letter-spacing: -0.3px; }
+    .featured-highlight:hover { box-shadow: var(--shadow-card); }
+    .featured-highlight h3 { font-family: 'Inter', sans-serif; font-size: 14px; font-weight: 600; color: var(--near-black); letter-spacing: -0.2px; }
 
     .empty-state {
       grid-column: 1 / -1; padding: 64px 40px; text-align: center;
-      background: white; border-radius: 16px; box-shadow: rgb(224,226,232) 0px 0px 0px 1px;
+      background: white; border-radius: 12px; box-shadow: var(--shadow-card);
     }
-    .empty-state h4 { font-family: 'Plus Jakarta Sans', sans-serif; font-size: 20px; font-weight: 700; letter-spacing: -0.5px; margin-bottom: 10px; }
-    .empty-state p { color: var(--slate); margin-bottom: 24px; font-size: 15px; }
+    .empty-state h4 { font-family: 'Inter', sans-serif; font-size: 20px; font-weight: 700; letter-spacing: -0.5px; margin-bottom: 10px; }
+    .empty-state p { color: var(--warm-gray); margin-bottom: 24px; font-size: 15px; }
 
     /* ─── SKILLS MATRIX ─── */
-    .skills-section { background: var(--rose-light); }
+    .skills-section { background: var(--bg-subtle); }
     .skills-layout { display: grid; grid-template-columns: 1fr 1fr; gap: 64px; align-items: start; }
     @media (max-width: 900px) { .skills-layout { grid-template-columns: 1fr; gap: 40px; } }
 
     .skill-category { margin-bottom: 36px; }
     .skill-category:last-child { margin-bottom: 0; }
     .skill-category-label {
-      font-family: 'Plus Jakarta Sans', sans-serif;
-      font-size: 11px; font-weight: 700; letter-spacing: 1px; text-transform: uppercase;
+      font-family: 'Inter', sans-serif;
+      font-size: 11px; font-weight: 600; letter-spacing: 0.5px; text-transform: uppercase;
       color: var(--blue); margin-bottom: 20px; display: flex; align-items: center; gap: 10px;
     }
-    .skill-category-label::after { content: ''; flex: 1; height: 1px; background: rgba(91,118,254,0.2); }
+    .skill-category-label::after { content: ''; flex: 1; height: 1px; background: rgba(0,117,222,0.15); }
 
     .skill-row { margin-bottom: 16px; }
     .skill-meta { display: flex; justify-content: space-between; align-items: baseline; margin-bottom: 8px; }
     .skill-name { font-size: 14px; font-weight: 500; color: var(--near-black); }
-    .skill-level { font-family: 'Plus Jakarta Sans', sans-serif; font-size: 11px; font-weight: 700; letter-spacing: 0.5px; color: var(--slate); }
-    .skill-bar { height: 4px; background: rgba(91,118,254,0.12); border-radius: 4px; position: relative; overflow: hidden; }
+    .skill-level { font-family: 'Inter', sans-serif; font-size: 11px; font-weight: 700; letter-spacing: 0.5px; color: var(--warm-gray); }
+    .skill-bar { height: 4px; background: rgba(0,117,222,0.1); border-radius: 4px; position: relative; overflow: hidden; }
     .skill-fill {
       position: absolute; left: 0; top: 0; height: 100%;
-      background: linear-gradient(90deg, var(--blue) 0%, rgba(91,118,254,0.65) 100%);
+      background: linear-gradient(90deg, var(--blue) 0%, rgba(0,117,222,0.55) 100%);
       border-radius: 4px; width: 0%; transition: width 1.2s var(--ease-smooth);
     }
 
     /* Specialty badges */
     .specialty-grid { display: grid; grid-template-columns: repeat(2, 1fr); gap: 12px; margin-top: 8px; }
     .specialty-badge {
-      padding: 16px; background: white; border-radius: 16px;
-      box-shadow: rgb(224,226,232) 0px 0px 0px 1px;
+      padding: 16px; background: white; border-radius: 12px;
+      box-shadow: var(--shadow-card);
       transition: box-shadow 0.3s ease, transform 0.3s var(--ease-spring);
     }
-    .specialty-badge:hover { box-shadow: rgb(224,226,232) 0px 0px 0px 1px, 0 8px 24px rgba(91,118,254,0.1); transform: translateY(-3px); }
+    .specialty-badge:hover { box-shadow: var(--shadow-card-hover); transform: translateY(-3px); }
     .specialty-badge-icon { font-size: 22px; margin-bottom: 10px; display: block; }
-    .specialty-badge-name { font-family: 'Plus Jakarta Sans', sans-serif; font-size: 13px; font-weight: 700; color: var(--near-black); display: block; margin-bottom: 6px; letter-spacing: -0.3px; }
-    .specialty-badge-desc { font-size: 12px; color: var(--slate); line-height: 1.5; }
+    .specialty-badge-name { font-family: 'Inter', sans-serif; font-size: 13px; font-weight: 600; color: var(--near-black); display: block; margin-bottom: 6px; letter-spacing: -0.2px; }
+    .specialty-badge-desc { font-size: 12px; color: var(--warm-gray); line-height: 1.5; }
 
     /* ─── END-TO-END PIPELINE ─── */
-    .pipeline-section { background: var(--orange-light); }
+    .pipeline-section { background: var(--bg); }
     .pipeline-intro { max-width: 680px; margin-bottom: 56px; }
-    .pipeline-intro p { font-size: 17px; color: var(--slate); line-height: 1.75; margin-top: 16px; }
+    .pipeline-intro p { font-size: 17px; color: var(--warm-gray); line-height: 1.75; margin-top: 16px; }
 
     .pipeline-track { position: relative; }
     .pipeline-steps { display: grid; grid-template-columns: repeat(5, 1fr); gap: 0; position: relative; }
@@ -555,7 +542,7 @@
 
     .pipeline-line {
       position: absolute; top: 36px; left: 10%; right: 10%; height: 1px;
-      background: linear-gradient(90deg, transparent 0%, rgba(91,118,254,0.4) 20%, rgba(91,118,254,0.6) 50%, rgba(91,118,254,0.4) 80%, transparent 100%);
+      background: linear-gradient(90deg, transparent 0%, rgba(0,117,222,0.35) 20%, rgba(0,117,222,0.5) 50%, rgba(0,117,222,0.35) 80%, transparent 100%);
       z-index: 0; transform: scaleX(0); transform-origin: left;
       transition: transform 1.4s var(--ease-smooth);
     }
@@ -571,32 +558,32 @@
 
     .pipeline-node {
       width: 72px; height: 72px; margin: 0 auto 20px;
-      background: white; border-radius: 20px;
-      box-shadow: rgb(224,226,232) 0px 0px 0px 1px;
+      background: white; border-radius: 16px;
+      box-shadow: var(--shadow-card);
       display: flex; align-items: center; justify-content: center;
       font-size: 26px; position: relative;
       transition: box-shadow 0.3s ease, transform 0.3s var(--ease-spring);
     }
-    .pipeline-step:hover .pipeline-node { box-shadow: rgb(224,226,232) 0px 0px 0px 1px, 0 8px 24px rgba(91,118,254,0.15); transform: scale(1.08); }
+    .pipeline-step:hover .pipeline-node { box-shadow: var(--shadow-card-hover); transform: scale(1.08); }
     .pipeline-node::after { display: none; }
 
     .pipeline-step-num {
       position: absolute; top: -8px; right: -8px;
       width: 22px; height: 22px; background: var(--blue); border-radius: 50%;
-      font-family: 'Plus Jakarta Sans', sans-serif; font-size: 11px; font-weight: 700;
+      font-family: 'Inter', sans-serif; font-size: 11px; font-weight: 600;
       display: flex; align-items: center; justify-content: center; color: white;
     }
-    .pipeline-step-title { font-family: 'Plus Jakarta Sans', sans-serif; font-size: 13px; font-weight: 700; color: var(--near-black); margin-bottom: 8px; letter-spacing: -0.3px; }
+    .pipeline-step-title { font-family: 'Inter', sans-serif; font-size: 13px; font-weight: 600; color: var(--near-black); margin-bottom: 8px; letter-spacing: -0.2px; }
     .pipeline-step-tools { display: flex; flex-wrap: wrap; gap: 4px; justify-content: center; margin-bottom: 10px; }
     .pipeline-tool {
-      font-family: 'Plus Jakarta Sans', sans-serif; font-size: 10px; font-weight: 700;
-      padding: 3px 9px; background: rgba(91,118,254,0.1); border: 1px solid rgba(91,118,254,0.25);
-      border-radius: 20px; color: var(--blue);
+      font-family: 'Inter', sans-serif; font-size: 10px; font-weight: 600;
+      padding: 3px 9px; background: rgba(0,117,222,0.07); border: 1px solid rgba(0,117,222,0.18);
+      border-radius: 9999px; color: var(--blue);
     }
-    .pipeline-step-desc { font-size: 12px; color: var(--slate); line-height: 1.5; }
+    .pipeline-step-desc { font-size: 12px; color: var(--warm-gray); line-height: 1.5; }
 
     @media (max-width: 900px) {
-      .pipeline-step { padding: 20px; text-align: left; background: white; border-radius: 16px; box-shadow: rgb(224,226,232) 0px 0px 0px 1px; display: flex; align-items: flex-start; gap: 16px; }
+      .pipeline-step { padding: 20px; text-align: left; background: white; border-radius: 12px; box-shadow: var(--shadow-card); display: flex; align-items: flex-start; gap: 16px; }
       .pipeline-node { width: 52px; height: 52px; font-size: 22px; flex-shrink: 0; margin: 0; }
       .pipeline-step-title { margin-top: 2px; }
     }
@@ -604,16 +591,16 @@
     /* Use case chips */
     .use-case-strip { display: flex; flex-wrap: wrap; gap: 10px; margin-top: 48px; justify-content: center; }
     .use-case-chip {
-      padding: 10px 20px; background: white; border-radius: 50px;
-      box-shadow: rgb(224,226,232) 0px 0px 0px 1px;
-      font-family: 'Plus Jakarta Sans', sans-serif; font-size: 13px; font-weight: 500; color: var(--near-black);
+      padding: 9px 18px; background: white; border-radius: 9999px;
+      box-shadow: var(--shadow-card);
+      font-family: 'Inter', sans-serif; font-size: 13px; font-weight: 500; color: var(--near-black);
       transition: box-shadow 0.2s ease, transform 0.2s var(--ease-spring);
     }
-    .use-case-chip:hover { box-shadow: rgb(224,226,232) 0px 0px 0px 1px, 0 4px 16px rgba(91,118,254,0.1); transform: translateY(-2px); }
+    .use-case-chip:hover { box-shadow: var(--shadow-card-hover); transform: translateY(-2px); }
     .use-case-chip span { color: var(--blue); margin-right: 4px; }
 
     /* ─── FREELANCE CTA ─── */
-    .freelance-section { background: var(--blue); border: none; }
+    .freelance-section { background: var(--bg-subtle); }
     .freelance-inner {
       display: grid; grid-template-columns: 1fr auto; gap: 64px; align-items: center;
       padding: 72px 0;
@@ -622,97 +609,98 @@
 
     .freelance-tag {
       display: inline-flex; align-items: center; gap: 8px;
-      font-family: 'Plus Jakarta Sans', sans-serif;
-      font-size: 12px; font-weight: 700; letter-spacing: 1px; text-transform: uppercase;
-      color: rgba(255,255,255,0.8); margin-bottom: 16px;
+      font-family: 'Inter', sans-serif;
+      font-size: 12px; font-weight: 600; letter-spacing: 0.5px; text-transform: uppercase;
+      color: var(--warm-gray); margin-bottom: 16px;
     }
-    .freelance-tag::before { content: ''; width: 7px; height: 7px; background: var(--success); border-radius: 50%; animation: pulse 2s infinite; }
+    .freelance-tag::before { content: ''; width: 6px; height: 6px; background: var(--success); border-radius: 50%; animation: pulse 2s infinite; }
     .freelance-heading {
-      font-family: 'Plus Jakarta Sans', sans-serif;
-      font-size: clamp(28px, 4vw, 48px); font-weight: 800;
-      letter-spacing: -1.5px; line-height: 1.1; margin-bottom: 20px; color: white;
+      font-family: 'Inter', sans-serif;
+      font-size: clamp(28px, 4vw, 48px); font-weight: 700;
+      letter-spacing: -1.5px; line-height: 1.1; margin-bottom: 20px; color: var(--near-black);
     }
-    .freelance-heading span { color: rgba(255,255,255,0.65); }
-    .freelance-body { font-size: 16px; color: rgba(255,255,255,0.8); max-width: 560px; line-height: 1.75; margin-bottom: 28px; }
+    .freelance-heading span { color: var(--warm-gray); }
+    .freelance-body { font-size: 16px; color: var(--warm-gray); max-width: 560px; line-height: 1.75; margin-bottom: 28px; }
     .freelance-services { display: flex; flex-wrap: wrap; gap: 8px; }
     .freelance-service {
-      padding: 7px 16px; background: rgba(255,255,255,0.12); border: 1px solid rgba(255,255,255,0.25);
-      border-radius: 20px; font-family: 'Plus Jakarta Sans', sans-serif;
-      font-size: 12px; font-weight: 600; color: white;
+      padding: 6px 14px; background: white; border: 1px solid var(--border);
+      border-radius: 9999px; font-family: 'Inter', sans-serif;
+      font-size: 12px; font-weight: 500; color: var(--warm-black);
     }
     .freelance-cta { display: flex; flex-direction: column; align-items: center; gap: 16px; }
-    .cta-availability { text-align: center; font-family: 'Plus Jakarta Sans', sans-serif; font-size: 12px; color: rgba(255,255,255,0.7); letter-spacing: 0.5px; }
-    .cta-dot { display: inline-block; width: 7px; height: 7px; background: var(--success); border-radius: 50%; margin-right: 6px; animation: pulse 2s infinite; }
+    .cta-availability { text-align: center; font-family: 'Inter', sans-serif; font-size: 12px; color: var(--warm-gray); letter-spacing: 0.3px; }
+    .cta-dot { display: inline-block; width: 6px; height: 6px; background: var(--success); border-radius: 50%; margin-right: 6px; animation: pulse 2s infinite; }
 
     /* ─── IMPACT STATS STRIP ─── */
-    .impact-stats-section { padding: 64px 0; background: var(--teal-light); border-top: none; border-bottom: none; }
+    .impact-stats-section { padding: 64px 0; background: var(--bg-subtle); border-top: 1px solid var(--border); border-bottom: 1px solid var(--border); }
     .impact-stats-grid { display: grid; grid-template-columns: repeat(4, 1fr); gap: 0; }
     .impact-stat {
       display: flex; flex-direction: column; align-items: center; justify-content: center;
-      padding: 24px 20px; text-align: center; border-right: 1px solid rgba(24,117,116,0.2);
+      padding: 24px 20px; text-align: center; border-right: 1px solid var(--border);
     }
     .impact-stat:last-child { border-right: none; }
     .impact-value {
-      font-family: 'Plus Jakarta Sans', sans-serif;
-      font-size: clamp(40px, 5vw, 64px); font-weight: 800; letter-spacing: -2px;
-      color: var(--teal-dark); line-height: 1;
+      font-family: 'Inter', sans-serif;
+      font-size: clamp(40px, 5vw, 64px); font-weight: 700; letter-spacing: -2.125px;
+      color: var(--near-black); line-height: 1;
     }
-    .impact-label { font-family: 'Plus Jakarta Sans', sans-serif; font-size: 13px; font-weight: 600; color: var(--teal-dark); margin-top: 8px; opacity: 0.8; }
+    .impact-label { font-family: 'Inter', sans-serif; font-size: 13px; font-weight: 500; color: var(--warm-gray); margin-top: 8px; }
     @media (max-width: 768px) {
       .impact-stats-grid { grid-template-columns: repeat(2, 1fr); }
       .impact-stat:nth-child(2) { border-right: none; }
-      .impact-stat:nth-child(3) { border-right: 1px solid rgba(24,117,116,0.2); border-top: 1px solid rgba(24,117,116,0.2); }
-      .impact-stat:nth-child(4) { border-right: none; border-top: 1px solid rgba(24,117,116,0.2); }
+      .impact-stat:nth-child(3) { border-right: 1px solid var(--border); border-top: 1px solid var(--border); }
+      .impact-stat:nth-child(4) { border-right: none; border-top: 1px solid var(--border); }
     }
     @media (max-width: 480px) {
       .impact-stats-grid { grid-template-columns: 1fr; }
-      .impact-stat { border-right: none !important; border-top: 1px solid rgba(24,117,116,0.2); }
+      .impact-stat { border-right: none !important; border-top: 1px solid var(--border); }
       .impact-stat:first-child { border-top: none; }
     }
 
     /* ─── QUERY-U FEATURED PROJECT ─── */
-    .queryu-section { background: white; }
+    .queryu-section { background: var(--bg-subtle); }
     .queryu-card {
-      background: linear-gradient(135deg, #ffe1e1 0%, #ffd8f4 100%);
-      border-radius: 32px; padding: 56px;
+      background: white;
+      border: 1px solid var(--border);
+      border-radius: 16px; padding: 56px;
       display: grid; grid-template-columns: 1.05fr 1fr; gap: 56px; align-items: center;
-      box-shadow: rgb(224,226,232) 0px 0px 0px 1px;
+      box-shadow: var(--shadow-card);
     }
     @media (max-width: 900px) { .queryu-card { grid-template-columns: 1fr; padding: 32px; gap: 32px; } }
 
     .queryu-tag {
       display: inline-flex; align-items: center; gap: 8px;
-      padding: 6px 14px; background: rgba(28,28,30,0.08); border-radius: 50px;
-      font-family: 'Plus Jakarta Sans', sans-serif;
-      font-size: 12px; font-weight: 700; letter-spacing: 1px; text-transform: uppercase;
-      color: var(--near-black); margin-bottom: 20px;
+      padding: 5px 12px; background: rgba(0,117,222,0.07); border: 1px solid rgba(0,117,222,0.15); border-radius: 9999px;
+      font-family: 'Inter', sans-serif;
+      font-size: 12px; font-weight: 600; letter-spacing: 0.3px; text-transform: uppercase;
+      color: var(--blue); margin-bottom: 20px;
     }
     .queryu-heading {
-      font-family: 'Plus Jakarta Sans', sans-serif;
-      font-size: clamp(28px, 3.5vw, 40px); font-weight: 800;
+      font-family: 'Inter', sans-serif;
+      font-size: clamp(28px, 3.5vw, 40px); font-weight: 700;
       letter-spacing: -1.5px; line-height: 1.1; color: var(--near-black); margin-bottom: 20px;
     }
     .queryu-heading em { font-style: normal; color: var(--blue); }
-    .queryu-body { font-size: 16px; color: var(--near-black); line-height: 1.7; margin-bottom: 14px; opacity: 0.82; }
+    .queryu-body { font-size: 16px; color: var(--warm-gray); line-height: 1.7; margin-bottom: 14px; }
     .queryu-actions { display: flex; gap: 12px; flex-wrap: wrap; margin-top: 24px; }
     .queryu-stats {
       display: grid; grid-template-columns: repeat(3, 1fr); gap: 16px;
-      margin-top: 28px; padding-top: 24px; border-top: 1px solid rgba(28,28,30,0.12);
+      margin-top: 28px; padding-top: 24px; border-top: 1px solid var(--border);
     }
     .queryu-stat-value {
-      font-family: 'Plus Jakarta Sans', sans-serif;
-      font-size: 28px; font-weight: 800; color: var(--near-black);
+      font-family: 'Inter', sans-serif;
+      font-size: 28px; font-weight: 700; color: var(--near-black);
       letter-spacing: -1px; display: block; line-height: 1;
     }
     .queryu-stat-label {
-      font-family: 'Plus Jakarta Sans', sans-serif;
-      font-size: 11px; font-weight: 600; color: var(--near-black); opacity: 0.7;
+      font-family: 'Inter', sans-serif;
+      font-size: 11px; font-weight: 500; color: var(--warm-gray);
       margin-top: 6px; display: block; letter-spacing: 0.3px; text-transform: uppercase;
     }
 
     .queryu-editor {
-      background: #1e1e2e; border-radius: 16px; overflow: hidden;
-      box-shadow: 0 20px 60px rgba(28,28,30,0.18);
+      background: #1e1e2e; border-radius: 12px; overflow: hidden;
+      box-shadow: var(--shadow-elevated);
     }
     .queryu-editor-header {
       display: flex; align-items: center; gap: 8px;
@@ -738,12 +726,12 @@
     .queryu-editor-code .number { color: var(--code-number); }
     .queryu-result {
       display: flex; justify-content: space-between; align-items: center;
-      padding: 12px 24px; background: rgba(0,180,115,0.15);
-      border-top: 1px solid rgba(0,180,115,0.3);
+      padding: 12px 24px; background: rgba(15,123,85,0.12);
+      border-top: 1px solid rgba(15,123,85,0.22);
     }
     .queryu-result-status {
-      font-family: 'Plus Jakarta Sans', sans-serif;
-      font-size: 13px; font-weight: 700; color: #4ade80;
+      font-family: 'Inter', sans-serif;
+      font-size: 13px; font-weight: 600; color: #4ade80;
     }
     .queryu-result-meta {
       font-family: 'JetBrains Mono', monospace;
@@ -759,12 +747,12 @@
     #page-loader.done { opacity: 0; pointer-events: none; }
     .loader-inner { text-align: center; }
     .loader-logo {
-      font-family: 'Plus Jakarta Sans', sans-serif; font-size: 48px; font-weight: 800;
+      font-family: 'Inter', sans-serif; font-size: 48px; font-weight: 700;
       color: var(--blue); letter-spacing: -3px;
     }
     .loader-bar {
-      width: 120px; height: 3px; background: var(--ring);
-      margin: 16px auto 0; overflow: hidden; border-radius: 4px;
+      width: 120px; height: 2px; background: rgba(0,0,0,0.08);
+      margin: 16px auto 0; overflow: hidden; border-radius: 2px;
     }
     .loader-progress {
       height: 100%; width: 0%; background: var(--blue); border-radius: 4px;
@@ -788,7 +776,6 @@
       .profile-card, .logo, nav a, .dashboard-card, .pipeline-step {
         opacity: 1 !important; transform: none !important;
       }
-      .hero::before, .hero::after { display: none; }
     }
   </style>
 </head>


### PR DESCRIPTION
## Summary

- Replace Miro theme (Plus Jakarta Sans, #5b76fe, pastel teal/coral/rose sections) with Notion's warm neutral design system
- Switch font to Inter (400/500/600/700) with aggressive display letter-spacing (−2.125px at 64px)
- New color palette: Notion Blue #0075de, warm white #f6f5f4, warm grays (#615d59, #a39e98, #31302e)
- Multi-layer card shadow stacks replace ring-border shadows
- Whisper borders: `rgba(0,0,0,0.1)` throughout
- Sections alternate clean white ↔ warm white instead of pastels
- Removed hero pastel radial gradients — clean white canvas
- Freelance CTA migrated from solid blue section to warm white with blue CTA button
- Impact stats strip: warm white bg, near-black numerals (was teal)
- Skills section: warm white bg (was rose)
- Pipeline section: clean white (was orange)
- QueryU card: clean white card with whisper border (was coral/rose gradient)
- All border-radius updated: cards 12px, hero card 16px, buttons 4px, tags/chips 9999px (pills)

## Test plan

- [ ] Load the portfolio and verify Inter font renders correctly
- [ ] Check hero section is clean white with no gradient blobs
- [ ] Verify dashboard cards show multi-layer shadows on hover
- [ ] Check freelance CTA section looks clean (warm white bg, dark text, blue button)
- [ ] Verify impact stats show near-black numbers (not teal)
- [ ] Confirm tags are pill-shaped (9999px radius)
- [ ] Test on mobile (skills, pipeline, QueryU sections)

https://claude.ai/code/session_01N7FPY66Q2orTxWFJZGo79j

---
_Generated by [Claude Code](https://claude.ai/code/session_01N7FPY66Q2orTxWFJZGo79j)_