### PR TITLE
Update location to Orlando and employer to UCF

### DIFF
--- a/consulting/index.html
+++ b/consulting/index.html
@@ -416,7 +416,7 @@
           </div>
           <div class="hero-meta-item">
             <div class="label">Based in</div>
-            <div class="value">Dallas–Fort Worth, TX</div>
+            <div class="value">Orlando, FL</div>
           </div>
         </div>
       </div>

--- a/index.html
+++ b/index.html
@@ -903,7 +903,7 @@
             <img src="https://i.imgur.com/1veEFe5.jpeg" alt="Davenee James" class="profile-avatar">
             <div class="profile-info">
               <h3>DAVENEE JAMES</h3>
-              <p>Data Analyst / BI Developer<br/>Southwestern Adventist University</p>
+              <p>Data Analyst / BI Developer<br/>University of Central Florida</p>
             </div>
           </div>
           <div class="profile-meta">
@@ -917,7 +917,7 @@
             </div>
             <div class="meta-item">
               <span class="meta-label">Location</span>
-              <span class="meta-value">Dallas–Fort Worth Metroplex</span>
+              <span class="meta-value">Orlando, FL</span>
             </div>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- Update profile card on the main page to show University of Central Florida as the current employer (was Southwestern Adventist University).
- Update location from Dallas–Fort Worth Metroplex to Orlando, FL on the main page.
- Update the "Based in" meta on the consulting page hero from Dallas–Fort Worth, TX to Orlando, FL.

## Test plan
- [ ] Load `index.html` and confirm the profile card shows "University of Central Florida" and location "Orlando, FL".
- [ ] Load `consulting/index.html` and confirm the hero meta shows "Based in: Orlando, FL".
- [ ] Confirm no other stale Dallas / Southwestern references remain (`grep -i dallas` / `grep -i southwestern` should be clean).

---
_Generated by [Claude Code](https://claude.ai/code/session_01YPQSSX5iArfjansmsVVDm4)_